### PR TITLE
HDDS-4795. Separate source of Ozone container images to different repositories

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+github:
+  description: "Container image to provide runtime environment for developing and testing Apache Ozone"
+  homepage: https://ozone.apache.org
+  labels:
+    - ozone
+    - container
+  enabled_merge_buttons:
+    squash:  true
+    merge:   false
+    rebase:  false
+notifications:
+  commits:      commits@ozone.apache.org
+  issues:       issues@ozone.apache.org
+  pullrequests: issues@ozone.apache.org
+  jira_options: link label worklog

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## What changes were proposed in this pull request?
+
+(Please fill in changes proposed in this fix)
+
+## What is the link to the Apache JIRA
+
+(Please create an issue in ASF JIRA before opening a pull request,
+and you need to set the title of the pull request which starts with
+the corresponding JIRA issue number. (e.g. HDDS-XXXX. Fix a typo in YYY.)
+
+Please replace this section with the link to the Apache JIRA)
+
+## How was this patch tested?
+
+(Please explain how this patch was tested. Ex: unit tests, manual tests)
+(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: build
+on:
+  - push
+jobs:
+  build:
+    name: build and deploy
+    runs-on: ubuntu-18.04
+    steps:
+      - name: checkout source
+        uses: actions/checkout@master
+      - name: build image
+        run: docker build -t ghcr.io/$(echo $GITHUB_REPOSITORY | sed 's/docker-//g') .

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,7 @@
 name: build
 on:
   - push
+  - pull_request
 jobs:
   build:
     name: build and deploy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+# Contributing
+
+For detailed contribution guideline, please check the [contribution guideline of Apache Ozone repository](https://github.com/apache/ozone/blob/master/CONTRIBUTING.md).
+

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ To build the image, please use:
 docker build -t apache/ozone-runner:dev .
 ```
 
-To test it with Apache Ozone, do a custom build:
+To test it, build [Apache Ozone](https://github.com/apache/ozone):
 
 ```
-mvn clean install -DskipTests -Dskip.npx -DskipShade -o -Ddocker.ozone-runner.version=dev
+mvn clean verify -DskipTests -Dskip.npx -DskipShade -Ddocker.ozone-runner.version=dev
 ```
 
 And start the compose cluster:

--- a/README.md
+++ b/README.md
@@ -15,15 +15,35 @@
   limitations under the License.
 -->
 
-# Apache Ozone runner base image
+# Apache Ozone **runner** base image
 
-This is the base image to run Apache Hadoop Ozone in docker containers. This is for test/develop and not for production.
+This is the base image to run Apache Hadoop Ozone in docker containers. This is only for test/develop and not for production.
 
-It doesn't include any Ozone specific jar files or release artifacts just any empty environment which includes all the specific tools to run Apache Hadoop Ozone inside containers.
+The container doesn't include any Ozone specific jar files or release artifacts just an empty environment which includes all the specific tools to run and test Apache Ozone inside containers.
 
-To build it, please use:
+The image is available as [apache/ozone-runner](https://hub.docker.com/r/apache/ozone-runner). Build is managed by Docker Hub.
+
+## Development
+
+To build the image, please use:
 
 ```
-docker build -t apache/ozone-runner
+docker build -t apache/ozone-runner:dev .
 ```
 
+To test it with Apache Ozone, do a custom build:
+
+```
+mvn clean install -DskipTests -Dskip.npx -DskipShade -o -Ddocker.ozone-runner.version=dev
+```
+
+And start the compose cluster:
+
+```
+cd hadoop-ozone/dist/target/ozone-*/compose/ozone
+docker-compose up -d
+```
+
+*After merging PR, a new tag should pushed to the repository to create a new image. Use the convention: `YYYYMMDD-N` for tags where N is a daily counter (see the existing tags as an example).
+
+After tag is published (and built by Docker Hub), the used runner version can be updated by modifying the `docker.ozone-runner.version` version in [hadoop-ozone/dist/pom.xml](https://github.com/apache/ozone/blob/master/hadoop-ozone/dist/pom.xml)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+This container image (`apache/ozone-runner`) is indented to be used only in *test and dev* environment. Please don't use it in production environment.
+
+The process of reporting Apache Ozone vulnerabilities [defined in the main Apache Ozone repository](https://github.com/apache/ozone/blob/master/SECURITY.md).


### PR DESCRIPTION
This PR contains basic cleanup after moving out the source of `apache/ozone-runner` to this repository.

Basic Github action workflow + standard descriptors (PR template, notification) + README update.