### PR TITLE
HDDS-4881. Pre-install awscli in ozone-runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN curl -LSs -o rocksdb-6.8.1.tar.gz https://github.com/facebook/rocksdb/archiv
 FROM centos@sha256:b5e66c4651870a1ad435cd75922fe2cb943c9e973a9673822d1414824a1d0475
 RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum install -y \
+      awscli \
       bzip2 \
       java-11-openjdk \
       jq \


### PR DESCRIPTION
## What changes were proposed in this pull request?

Pre-install `awscli` in the `ozone-runner` docker image to save some execution time in acceptance tests.

https://issues.apache.org/jira/browse/HDDS-4881

## How was this patch tested?

Built the image locally:

    docker build -t apache/ozone-runner:dev .

executed some Ozone acceptance test:

    cd ozone/hadoop-ozone/dist/target/ozone-1.1.0-SNAPSHOT/compose/ozone
    OZONE_RUNNER_VERSION=dev ./test.sh

and verified in `result/robot*xml` that `awscli` no longer has to be installed during acceptance test:

    Running command 'sudo -E yum install -y awscli 2&gt;&amp;1'.
    Package awscli-1.14.28-5.el7_5.1.noarch already installed and latest version