### PR TITLE
HDDS-4891. Avoid latest/master in Github Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,6 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: checkout source
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
       - name: build image
         run: docker build -t ghcr.io/$(echo $GITHUB_REPOSITORY | sed 's/docker-//g') .


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid versions `latest` (for runners) and `master` (for actions) in Github Actions workflows.

https://issues.apache.org/jira/browse/HDDS-4891

## How was this patch tested?

https://github.com/adoroszlai/ozone-docker-runner/runs/2013625849