### PR TITLE
HDDS-5025. Upgrade Async Profiler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,9 +71,9 @@ ADD https://repo.maven.apache.org/maven2/org/jboss/byteman/byteman/4.0.4/byteman
 RUN chmod o+r /opt/byteman.jar
 
 #async profiler for development profiling
-RUN mkdir -p /opt/profiler && \
-    cd /opt/profiler && \
-    curl -L https://github.com/jvm-profiling-tools/async-profiler/releases/download/v1.5/async-profiler-1.5-linux-x64.tar.gz | tar xvz
+RUN cd /opt && \
+    curl -L https://github.com/jvm-profiling-tools/async-profiler/releases/download/v2.0/async-profiler-2.0-linux-x64.tar.gz | tar xvz && \
+    mv async-profiler-2.0-linux-x64 profiler
 
 ENV JAVA_HOME=/usr/lib/jvm/jre/
 ENV LD_LIBRARY_PATH /usr/local/lib


### PR DESCRIPTION
## What changes were proposed in this pull request?

Async Profiler default output format is being changed in HDDS-5009 to one not supported by version 1.5.  We need to bump the version being installed in the image.

https://issues.apache.org/jira/browse/HDDS-5025

## How was this patch tested?

Built the image and ran the changes in https://github.com/apache/ozone/pull/2078 with it.

```
scm_1       | 2021-03-24 09:00:59,907 [qtp2054997292-347] INFO http.ProfileServlet: Servlet process PID: 7 asyncProfilerHome: /opt/profiler
scm_1       | 2021-03-24 09:00:59,922 [qtp2054997292-347] INFO http.ProfileServlet: Running command async: [/opt/profiler/profiler.sh, -e, cpu, -d, 10, -o, flamegraph, -f, /tmp/prof-output/async-prof-pid-7-cpu-1.html, 7]
scm_1       | Profiling started
scm_1       | Profiling for 10 seconds
scm_1       | 2021-03-24 09:01:10,603 [qtp2054997292-342] INFO http.ProfileServlet: /tmp/prof-output/async-prof-pid-7-cpu-1.html is incomplete. Sending auto-refresh header..
scm_1       | Done
```