### PR TITLE
HDDS-6023. Cannot rebuild ozone-runner due to undefined: os.ErrDeadlineExceeded

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.14.2-buster
+FROM golang:1.17.3-buster
 RUN GO111MODULE=off go get -u github.com/rexray/gocsi/csc
 
 FROM centos:7.6.1810


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the error:

```
...
Step 2/45 : RUN GO111MODULE=off go get -u github.com/rexray/gocsi/csc
 ---> Running in 8e018058512a
# golang.org/x/net/http2
src/golang.org/x/net/http2/transport.go:417:45: undefined: os.ErrDeadlineExceeded
The command '/bin/sh -c GO111MODULE=off go get -u github.com/rexray/gocsi/csc' returned a non-zero code: 2
```

by upgrading `go`.

https://issues.apache.org/jira/browse/HDDS-6023

## How was this patch tested?

Built the image locally, ran `ozone-csi` smoketest with it.

CI:
https://github.com/adoroszlai/ozone-docker-runner/runs/4274790893