### PR TITLE
HDDS-5967. Upgrade pip in ozone-runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ RUN yum install -y \
       sudo \
       wget \
       zlib
+RUN sudo python3 -m pip install --upgrade pip
 
 COPY --from=0 /go/bin/csc /usr/bin/csc
 COPY --from=1 /rocksdb-6.8.1/ldb /usr/local/bin/ldb


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade `pip` in `ozone-runner` Docker image to avoid:

```
$ cd hadoop-ozone/dist/target/ozone-1.3.0-SNAPSHOT/compose/ozone-om-ha
$ docker-compose build
...
 => ERROR [15/21] RUN sudo pip3 install robotframework-sshlibrary
...
executor failed running [/bin/sh -c sudo pip3 install robotframework-sshlibrary]: exit code: 1
ERROR: Service 'datanode' failed to build : Build failed
```

https://issues.apache.org/jira/browse/HDDS-5967

## How was this patch tested?

Built `ozone-runner` locally:

```
$ docker build -t apache/ozone-runner:HDDS-5967 .
...
 => [stage-2  4/31] RUN sudo python3 -m pip install --upgrade pip
...
 => => naming to docker.io/apache/ozone-runner:HDDS-5967
```

and used it to build temporary images for `ozone-om-ha` environment:

```
$ export OZONE_RUNNER_VERSION=HDDS-5967
$ cd hadoop-ozone/dist/target/ozone-1.3.0-SNAPSHOT/compose/ozone-om-ha
$ docker-compose build
...
 => [15/21] RUN sudo pip3 install robotframework-sshlibrary
...
 => => naming to docker.io/library/ozone-runner-om-ha:HDDS-5967
```