### PR TITLE
HDDS-6264. Bump centos to 7.9.2009, dependencies and tools in ozone-runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,6 @@ FROM centos:8.4.2105
 RUN sed -i -e 's/^mirrorlist/#&/' -e 's/^#baseurl/baseurl/' -e 's/mirror.centos.org/vault.centos.org/' /etc/yum.repos.d/*.repo
 RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 RUN yum install -y \
-      awscli \
       bzip2 \
       java-11-openjdk \
       jq \
@@ -60,7 +59,8 @@ RUN yum install -y \
       snappy \
       sudo \
       wget \
-      zlib
+      zlib \
+      diffutils
 RUN sudo python3 -m pip install --upgrade pip
 # Create python symlink for compatiblity
 RUN ln -s /usr/bin/python3 /usr/bin/python
@@ -70,7 +70,7 @@ COPY --from=1 /rocksdb-6.28.2/ldb /usr/local/bin/ldb
 COPY --from=1 /usr/local/lib /usr/local/lib/
 
 #For executing inline smoketest
-RUN pip3 install robotframework boto3
+RUN pip3 install awscli robotframework boto3
 
 #dumb init for proper init handling
 RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64
@@ -116,6 +116,9 @@ RUN mkdir /data && chmod 1777 /data
 #default entrypoint (used only if the ozone dir is not bindmounted)
 ADD entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod 755 /usr/local/bin/entrypoint.sh
+
+# Fix error when ssh'ing into other containers: System is booting up. Unprivileged users are not permitted to log in yet.
+RUN rm -f /run/nologin
 
 WORKDIR /opt/hadoop
 USER hadoop

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,28 +24,36 @@ RUN yum -y install \
       gcc gcc-c++ \
       make \
       which \
-      cmake3
+      cmake3 \
+      perl
 RUN ln -s /usr/bin/cmake3 /usr/bin/cmake
-RUN curl -LSs -o gflags-src.tar.gz https://github.com/gflags/gflags/archive/v2.2.2.tar.gz \
+RUN export GFLAGS_VER=2.2.2 \
+      && curl -LSs -o gflags-src.tar.gz https://github.com/gflags/gflags/archive/v${GFLAGS_VER}.tar.gz \
       && tar zxvf gflags-src.tar.gz \
-      && cd gflags-2.2.2 \
+      && rm gflags-src.tar.gz \
+      && cd gflags-${GFLAGS_VER} \
       && mkdir build \
       && cd build \
       && cmake .. \
       && make -j$(nproc) \
       && make install \
       && cd ../.. \
-      && rm -rf gflags-2.2.2
-RUN curl -LSs -o zstd-src.tar.gz https://github.com/facebook/zstd/archive/v1.5.2.tar.gz \
+      && rm -rf gflags-${GFLAGS_VER}
+RUN export ZSTD_VER=1.5.2 \
+      && curl -LSs -o zstd-src.tar.gz https://github.com/facebook/zstd/archive/v${ZSTD_VER}.tar.gz \
       && tar zxvf zstd-src.tar.gz \
-      && cd zstd-1.5.2 \
+      && rm zstd-src.tar.gz \
+      && cd zstd-${ZSTD_VER} \
       && make -j$(nproc) \
       && make install \
       && cd .. \
-      && rm -rf zstd-1.5.2
-RUN curl -LSs -o rocksdb-src.tar.gz https://github.com/facebook/rocksdb/archive/v6.28.2.tar.gz \
+      && rm -rf zstd-${ZSTD_VER}
+RUN export ROCKSDB_VER=6.28.2 \
+      && curl -LSs -o rocksdb-src.tar.gz https://github.com/facebook/rocksdb/archive/v${ROCKSDB_VER}.tar.gz \
       && tar xzvf rocksdb-src.tar.gz \
-      && cd rocksdb-6.28.2 \
+      && rm rocksdb-src.tar.gz \
+      && mv rocksdb-${ROCKSDB_VER} rocksdb \
+      && cd rocksdb \
       && make -j$(nproc) ldb
 
 FROM centos:7.9.2009
@@ -64,7 +72,7 @@ RUN yum install -y \
 RUN sudo python3 -m pip install --upgrade pip
 
 COPY --from=0 /go/bin/csc /usr/bin/csc
-COPY --from=1 /rocksdb-6.28.2/ldb /usr/local/bin/ldb
+COPY --from=1 /rocksdb/ldb /usr/local/bin/ldb
 COPY --from=1 /usr/local/lib /usr/local/lib/
 
 #For executing inline smoketest
@@ -94,7 +102,7 @@ RUN echo "hadoop ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
 RUN chown hadoop /opt
 
-#Be prepared for kerbebrizzed cluster
+# Prep for Kerberized cluster
 RUN mkdir -p /etc/security/keytabs && chmod -R a+wr /etc/security/keytabs 
 ADD krb5.conf /etc/
 RUN chmod 644 /etc/krb5.conf
@@ -105,13 +113,13 @@ RUN wget https://github.com/kahing/goofys/releases/download/v0.24.0/goofys -O /u
 RUN chmod 755 /usr/bin/goofys
 RUN yum install -y fuse
 
-#Make it compatible with any UID/GID (write premission may be missing to /opt/hadoop
+# Create hadoop and data directories. Grant all permission to all on them
 RUN mkdir -p /etc/hadoop && mkdir -p /var/log/hadoop && chmod 1777 /etc/hadoop && chmod 1777 /var/log/hadoop
 ENV OZONE_LOG_DIR=/var/log/hadoop
 ENV OZONE_CONF_DIR=/etc/hadoop
 RUN mkdir /data && chmod 1777 /data
 
-#default entrypoint (used only if the ozone dir is not bindmounted)
+# Set default entrypoint (used only if the ozone dir is not bind mounted)
 ADD entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod 755 /usr/local/bin/entrypoint.sh
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Bump golang base image to [1.17.6](https://hub.docker.com/_/golang?tab=tags&page=1&name=1.17) (was 1.17.3)
- Bump centos base image to [7.9.2009](https://hub.docker.com/_/centos?tab=tags&page=1&name=7.9) (was [7.6.1810](https://hub.docker.com/_/centos?tab=tags&page=1&name=7.6))
  - ~~Incorporated [HDDS-6239](https://github.com/apache/ozone/pull/3029) into Dockerfile (centos vault repo url change). `yum install` will fail without it.~~ no longer the case as centos 7 is not EOL, unlike centos 8.
- Remove unused dependencies `bzip2-devel`, `gcc48-c++`, `lz4-devel`, `snappy-devel`, `zlib-devel`, `git` in second stage (stage 1).
- Bump `gflags` to [2.2.2](https://github.com/gflags/gflags/releases) (was 2.0.0)
- Bump `zstd` to [1.5.2](https://github.com/facebook/zstd/releases) (was 1.1.3)
- Bump `rocksdb` to [6.28.2](https://github.com/facebook/rocksdb/releases) (was 6.8.1)
- Use [`make -j$(nproc)`](https://www.mankier.com/1/make#-j) to speed up the build process
- Bump `dumb-init` to [1.2.5](https://github.com/Yelp/dumb-init/releases) (was 1.2.0)
- Bump `byteman` to [4.0.9](https://repo.maven.apache.org/maven2/org/jboss/byteman/byteman/) (was 4.0.4)
- Bump `async-profiler` to [2.6](https://github.com/jvm-profiling-tools/async-profiler/releases) (was 2.0)
- Bump `goofys` to [0.24.0](https://github.com/kahing/goofys/releases) (was 0.20.0)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6264

## How was this patch tested?

Followed https://github.com/apache/ozone-docker-runner#development for local testing, on x86_64 (amd64 / x64) Linux only:

- Built image using `docker build -t apache/ozone-runner:dev .`
```bash
Successfully tagged apache/ozone-runner:dev
```

- Ran `mvn clean verify -DskipTests -Dskip.npx -DskipShade -Ddocker.ozone-runner.version=dev` on the ozone master branch (`e47b6f0c35`)
```bash
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  42.393 s
[INFO] Finished at: 2022-02-04T07:24:13-08:00
[INFO] ------------------------------------------------------------------------
```

- Started docker compose cluster `cd hadoop-ozone/dist/target/ozone-*/compose/ozone && docker-compose up`.
  - Checked logs, all services seems to have started as expected.
  - Accessed OM Web UI at http://localhost:9874
  - Accessed SCM Web UI at http://localhost:9876
  - Accessed S3 Gateway Web UI at http://localhost:9878
```
$ docker-compose ps
      Name                    Command               State                            Ports                         
-------------------------------------------------------------------------------------------------------------------
ozone_datanode_1   /usr/local/bin/dumb-init - ...   Up      0.0.0.0:49160->9864/tcp,:::49160->9864/tcp,            
                                                            0.0.0.0:49159->9882/tcp,:::49159->9882/tcp             
ozone_om_1         /usr/local/bin/dumb-init - ...   Up      0.0.0.0:9862->9862/tcp,:::9862->9862/tcp,              
                                                            0.0.0.0:9874->9874/tcp,:::9874->9874/tcp               
ozone_recon_1      /usr/local/bin/dumb-init - ...   Up      0.0.0.0:9888->9888/tcp,:::9888->9888/tcp               
ozone_s3g_1        /usr/local/bin/dumb-init - ...   Up      0.0.0.0:9878->9878/tcp,:::9878->9878/tcp               
ozone_scm_1        /usr/local/bin/dumb-init - ...   Up      0.0.0.0:9860->9860/tcp,:::9860->9860/tcp,              
                                                            0.0.0.0:9876->9876/tcp,:::9876->9876/tcp
```

- Ran `compose/test-all.sh`, all acceptance tests passed. (Took 53m55s in my x64 Linux box, or 48m23s excluding suite setups and teardowns)
  - [!] Note: `ozonesecure-ha` might still be buggy in the setup stage (which didn't show up in the report at all) as I tried in my Linux box.
    - But it works just fine when I run it on an Intel Mac. And all ha tests passed. Hmm