### PR TITLE
HDDS-6265. Add arm64 architecture support for ozone-runner docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17.6-buster
+FROM golang:1.17.7-buster AS go1
 RUN GO111MODULE=off go get -u github.com/rexray/gocsi/csc
 
-FROM centos:7.9.2009
+FROM golang:1.17.7-buster AS go2
+# Compile latest goofys for arm64 if necessary, which doesn't have a released binary
+RUN set -eux ; \
+    ARCH="$(arch)"; \
+    if [ ${ARCH} = "aarch64" ]; then \
+        git clone https://github.com/kahing/goofys.git ; \
+        cd goofys ; \
+        go env GOOS GOARCH ; \
+        GOOS=linux GOARCH=arm64 go build ; \
+        mv goofys /go/bin/ ; \
+    elif [ ${ARCH} = "x86_64" ]; then \
+        curl -L https://github.com/kahing/goofys/releases/download/v0.24.0/goofys -o /go/bin/goofys ; \
+    else \
+        echo "Unsupported architecture: ${ARCH}"; \
+        exit 1 ; \
+    fi
+
+FROM centos:7.9.2009 AS builder
 # Required for cmake3 package
 RUN yum -y install epel-release
 RUN yum -y install \
@@ -28,9 +45,7 @@ RUN yum -y install \
       perl
 RUN ln -s /usr/bin/cmake3 /usr/bin/cmake
 RUN export GFLAGS_VER=2.2.2 \
-      && curl -LSs -o gflags-src.tar.gz https://github.com/gflags/gflags/archive/v${GFLAGS_VER}.tar.gz \
-      && tar zxvf gflags-src.tar.gz \
-      && rm gflags-src.tar.gz \
+      && curl -LSs https://github.com/gflags/gflags/archive/v${GFLAGS_VER}.tar.gz | tar zxv \
       && cd gflags-${GFLAGS_VER} \
       && mkdir build \
       && cd build \
@@ -38,20 +53,16 @@ RUN export GFLAGS_VER=2.2.2 \
       && make -j$(nproc) \
       && make install \
       && cd ../.. \
-      && rm -rf gflags-${GFLAGS_VER}
+      && rm -r gflags-${GFLAGS_VER}
 RUN export ZSTD_VER=1.5.2 \
-      && curl -LSs -o zstd-src.tar.gz https://github.com/facebook/zstd/archive/v${ZSTD_VER}.tar.gz \
-      && tar zxvf zstd-src.tar.gz \
-      && rm zstd-src.tar.gz \
+      && curl -LSs https://github.com/facebook/zstd/archive/v${ZSTD_VER}.tar.gz | tar zxv \
       && cd zstd-${ZSTD_VER} \
       && make -j$(nproc) \
       && make install \
       && cd .. \
-      && rm -rf zstd-${ZSTD_VER}
+      && rm -r zstd-${ZSTD_VER}
 RUN export ROCKSDB_VER=6.28.2 \
-      && curl -LSs -o rocksdb-src.tar.gz https://github.com/facebook/rocksdb/archive/v${ROCKSDB_VER}.tar.gz \
-      && tar xzvf rocksdb-src.tar.gz \
-      && rm rocksdb-src.tar.gz \
+      && curl -LSs https://github.com/facebook/rocksdb/archive/v${ROCKSDB_VER}.tar.gz | tar zxv \
       && mv rocksdb-${ROCKSDB_VER} rocksdb \
       && cd rocksdb \
       && make -j$(nproc) ldb
@@ -66,34 +77,54 @@ RUN yum install -y \
       python3 python3-pip \
       snappy \
       sudo \
-      wget \
       zlib \
       diffutils
 RUN sudo python3 -m pip install --upgrade pip
 
-COPY --from=0 /go/bin/csc /usr/bin/csc
-COPY --from=1 /rocksdb/ldb /usr/local/bin/ldb
-COPY --from=1 /usr/local/lib /usr/local/lib/
+COPY --from=go1 /go/bin/csc /usr/bin/csc
+COPY --from=builder /rocksdb/ldb /usr/local/bin/ldb
+COPY --from=builder /usr/local/lib /usr/local/lib/
 
 #For executing inline smoketest
 RUN pip3 install awscli robotframework boto3
 
 #dumb init for proper init handling
-RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64
-RUN chmod +x /usr/local/bin/dumb-init
+RUN set -eux ; \
+    ARCH="$(arch)"; \
+    case "${ARCH}" in \
+        x86_64) \
+            url='https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64'; \
+            sha256='e874b55f3279ca41415d290c512a7ba9d08f98041b28ae7c2acb19a545f1c4df'; \
+            ;; \
+        aarch64) \
+            url='https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_aarch64'; \
+            sha256='c2b29d578ca70709c41141af37bf3816d21cb6624a46105850b74b336dfe22cd'; \
+            ;; \
+        *) echo "Unsupported architecture: ${ARCH}"; exit 1 ;; \
+    esac; \
+    curl -L ${url} -o dumb-init ; \
+    echo "${sha256} *dumb-init" | sha256sum -c - ; \
+    chmod +x dumb-init ; \
+    mv dumb-init /usr/local/bin/dumb-init
 
 #byteman test for development
 ADD https://repo.maven.apache.org/maven2/org/jboss/byteman/byteman/4.0.9/byteman-4.0.9.jar /opt/byteman.jar
 RUN chmod o+r /opt/byteman.jar
 
 #async profiler for development profiling
-RUN cd /opt && \
-    curl -L https://github.com/jvm-profiling-tools/async-profiler/releases/download/v2.6/async-profiler-2.6-linux-x64.tar.gz | tar xvz && \
-    mv async-profiler-2.6-linux-x64 profiler
+RUN set -eux ; \
+    ARCH="$(arch)" ; \
+    case "${ARCH}" in \
+        x86_64)  url='https://github.com/jvm-profiling-tools/async-profiler/releases/download/v2.7/async-profiler-2.7-linux-x64.tar.gz' ;; \
+        aarch64) url='https://github.com/jvm-profiling-tools/async-profiler/releases/download/v2.7/async-profiler-2.7-linux-arm64.tar.gz' ;; \
+        *) echo "Unsupported architecture: ${ARCH}"; exit 1 ;; \
+    esac; \
+    curl -L ${url} | tar xvz ; \
+    mv async-profiler-* /opt/profiler
 
 ENV JAVA_HOME=/usr/lib/jvm/jre/
-ENV LD_LIBRARY_PATH /usr/local/lib
-ENV PATH /opt/hadoop/libexec:$PATH:/opt/hadoop/bin
+ENV LD_LIBRARY_PATH=/usr/local/lib
+ENV PATH=/opt/hadoop/libexec:$PATH:/opt/hadoop/bin
 
 RUN groupadd --gid 1000 hadoop
 RUN useradd --uid 1000 hadoop --gid 100 --home /opt/hadoop
@@ -109,7 +140,7 @@ RUN chmod 644 /etc/krb5.conf
 RUN yum install -y krb5-workstation
 
 # CSI / k8s / fuse / goofys dependency
-RUN wget https://github.com/kahing/goofys/releases/download/v0.24.0/goofys -O /usr/bin/goofys
+COPY --from=go2 /go/bin/goofys /usr/bin/goofys
 RUN chmod 755 /usr/bin/goofys
 RUN yum install -y fuse
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Improve Dockerfile to select the right dependencies based on build architecture.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6265

## How was this patch tested?

- [x] Test on x86_64
- [ ] Test on arm64 (M1)
