### PR TITLE
HDDS-6359. Install JDK in runner image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ FROM centos:7.9.2009
 RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum install -y \
       bzip2 \
-      java-11-openjdk \
+      java-11-openjdk-devel \
       jq \
       nmap-ncat \
       python3 python3-pip \


### PR DESCRIPTION
## What changes were proposed in this pull request?

Install JDK instead of JRE in `ozone-runner` image, e.g. to be able to take heap/stack dumps.

https://issues.apache.org/jira/browse/HDDS-6359

## How was this patch tested?

https://github.com/adoroszlai/ozone-docker-runner/runs/5276229639#step:3:4047