### PR TITLE
HDDS-6524. Bump rocksdb ldb to 7.0.4 and others in ozone-runner; Reduce image size by ~20%

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,4 +24,4 @@ jobs:
       - name: checkout source
         uses: actions/checkout@v2
       - name: build image
-        run: docker build -t ghcr.io/$(echo $GITHUB_REPOSITORY | sed 's/docker-//g') .
+        run: DOCKER_BUILDKIT=1 docker build -t ghcr.io/$(echo $GITHUB_REPOSITORY | sed 's/docker-//g') .

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN export ZSTD_VER=1.5.2 \
       && make install \
       && cd .. \
       && rm -r zstd-${ZSTD_VER}
-RUN export ROCKSDB_VER=7.0.3 \
+RUN export ROCKSDB_VER=7.0.4 \
       && curl -LSs https://github.com/facebook/rocksdb/archive/v${ROCKSDB_VER}.tar.gz | tar zxv \
       && mv rocksdb-${ROCKSDB_VER} rocksdb \
       && cd rocksdb \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,20 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17.8-alpine AS go
+FROM golang:1.17.8-buster AS go
 RUN go install github.com/rexray/gocsi/csc@latest
 # Compile latest goofys for arm64 if necessary, which doesn't have a released binary
 RUN set -eux ; \
     ARCH="$(arch)"; \
     if [ ${ARCH} = "aarch64" ]; then \
-        apk add --update git ; \
         git clone https://github.com/kahing/goofys.git ; \
         cd goofys ; \
         git checkout 08534b2 ; \
         go build ; \
         mv goofys /go/bin/ ; \
     elif [ ${ARCH} = "x86_64" ]; then \
-        apk add --update curl ; \
         curl -L https://github.com/kahing/goofys/releases/download/v0.24.0/goofys -o /go/bin/goofys ; \
     else \
         echo "Unsupported architecture: ${ARCH}"; \

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The image is available as [apache/ozone-runner](https://hub.docker.com/r/apache/
 To build the image, please use:
 
 ```
-docker build -t apache/ozone-runner:dev .
+DOCKER_BUILDKIT=1 docker build -t apache/ozone-runner:dev .
 ```
 
 To test it, build [Apache Ozone](https://github.com/apache/ozone):

--- a/README.md
+++ b/README.md
@@ -47,3 +47,15 @@ docker-compose up -d
 *After merging PR, a new tag should pushed to the repository to create a new image. Use the convention: `YYYYMMDD-N` for tags where N is a daily counter (see the existing tags as an example).
 
 After tag is published (and built by Docker Hub), the used runner version can be updated by modifying the `docker.ozone-runner.version` version in [hadoop-ozone/dist/pom.xml](https://github.com/apache/ozone/blob/master/hadoop-ozone/dist/pom.xml)
+
+## Building multi-architecture images
+
+To build images with multiple architectures, use `docker buildx`.
+
+For example, to build images for both `linux/amd64` and `linux/arm64`, run:
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 -t apache/ozone-runner:dev . --progress=plain
+```
+
+It might be slow when building the non-native architecture image due to QEMU emulation.


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Bump rocksdb ldb to 7.0.3
- Bump gcc/g++ from 4 to 10 as rocksdb 7.x now requires gdb >= 7 to be compiled
  - I tried to bump g++ to 11 but CentOS 7 repo, for whatever reason, doesn't have one packaged for arm64 right now. g++ 10 also works fine as I tested.
    - https://pkgs.org/download/devtoolset-10-gcc-c++
    - https://pkgs.org/download/devtoolset-11-gcc-c++
- Bump golang from 1.17.7 to 1.17.8
  - 1.18.0 has some issues when compiling `goofys` from source in arm64 env.
  - ~~And changed to alpine image from buster to save 100 MB download.~~ Turns out go uses Alpine's musl libc this way which causes compatiblity issue with CentOS. And `musl-libc` [doesn't seem to have an arm64 package](https://pkgs.org/download/musl-libc) for CentOS 7. I have reverted this back to `-buster` image.
    - This is the error message when running go csc built in Alpine image in CentOS 7: `/bin/sh: /usr/bin/csc: /lib/ld-musl-x86_64.so.1: bad ELF interpreter: No such file or directory`
- Bump byteman from 4.0.9 to 4.0.18
- Perform `yum clean all` during image build, especially in the last stage. This step alone saves ~200 MB in final image size (on disk, uncompressed?)
  - <img width="943" alt="du" src="https://user-images.githubusercontent.com/50227127/160880822-57381639-ce84-4524-a934-3000cf556a5e.png"> via [Slim.AI](https://portal.slim.dev/home/xray/dockerhub%3A%2F%2Fdockerhub.public%2Fapache%2Fozone-runner%3A20220228-1%40sha256%3A4e7fac095177756b946899f202c1c5971ebc31e76cb6153695df453a84583487)
  - Previously, the two separate `yum install -y` commands repopulated the yum cache. They had to be done altogether in one layer to save size.
- Clean up pip cache
- Use `COPY --chmod`. This saves ~15 MB of avoiding duplicating `goofys` binary in the new overlayfs layer.
  - Ref: https://blog.vamc19.dev/posts/dockerfile-copy-chmod/
  - Note: `COPY --chmod` requires BuildKit. Use `DOCKER_BUILDKIT=1 docker build -t apache/ozone-runner:dev .` to build the image, or enable BuildKit by default. See https://docs.docker.com/develop/develop-images/build_enhancements/#to-enable-buildkit-builds

Before (current master):
```bash
$ docker images apache/ozone-runner
REPOSITORY            TAG          IMAGE ID       CREATED         SIZE
apache/ozone-runner   dev          fda5b1ea9314   9 minutes ago   1.12GB
```

After:
```bash
$ docker images apache/ozone-runner
REPOSITORY            TAG       IMAGE ID       CREATED          SIZE
apache/ozone-runner   dev       ed4a6ffb4111   58 seconds ago   921MB
```

To build multi-arch image, use:

```bash
docker buildx build --platform linux/amd64,linux/arm64 -t apache/ozone-runner:dev . --progress=plain
```

This should work on amd64 machines as well due to the (automatic) use of qemu.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6524

## How was this patch tested?

- [x] Build and run on amd64 (Intel). Pass all existing acceptance test suites.
- [ ] ~~Build and run on arm64 (M1). Pass all existing acceptance test suites.~~

## Sidenote

For M1 users, this can be an interesting read: https://rieckpil.de/java-development-on-an-apple-m1-a-one-year-review/