### PR TITLE
HDDS-7720. Create httpfs user and group

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -172,6 +172,10 @@ RUN groupadd --gid 1008 testuser2
 RUN useradd --uid 1008 testuser2 --gid 1008 --home /opt/testuser2
 RUN chmod 755 /opt/testuser2
 
+RUN groupadd --gid 1009 httpfs
+RUN useradd --uid 1009 httpfs --gid 1009 --home /opt/httpfs
+RUN chmod 755 /opt/httpfs
+
 # Prep for Kerberized cluster
 RUN mkdir -p /etc/security/keytabs && chmod -R a+wr /etc/security/keytabs 
 ADD krb5.conf /etc/


### PR DESCRIPTION
## What changes were proposed in this pull request?

I added `httpfs` user and group to this image, so the secure httpfs smoke tests will be able to run, as the Kerberos setup will work.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7720

## How was this patch tested?

Built the image locally with my change and used that with Ozone.
