### PR TITLE
HDDS-8488. Install openssl in runner image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,14 +80,14 @@ RUN set -eux ; \
       java-11-openjdk-devel \
       jq \
       nmap-ncat \
+      openssl \
       python3 python3-pip \
       snappy \
       sudo \
       zlib \
       diffutils \
       krb5-workstation \
-      fuse \
-      openssl ; \
+      fuse ; \
     yum clean all
 RUN sudo python3 -m pip install --upgrade pip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,8 @@ RUN set -eux ; \
       zlib \
       diffutils \
       krb5-workstation \
-      fuse ; \
+      fuse \
+      openssl ; \
     yum clean all
 RUN sudo python3 -m pip install --upgrade pip
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding the openssl command to the base docker image will allow testing certificate related cases. 

## What is the link to the Apache JIRA

[HDDS-8488](https://issues.apache.org/jira/browse/HDDS-8488)

## How was this patch tested?

Build the docker image locally and tested it first based on the dockerfile. Then paired it with ozone and all containers were able to run openssl. 