### PR TITLE
HDDS-8523. Upgrade Github Actions runner to ubuntu-latest

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,9 +19,9 @@ on:
 jobs:
   build:
     name: build and deploy
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: checkout source
         uses: actions/checkout@v2
       - name: build image
-        run: DOCKER_BUILDKIT=1 docker build -t ghcr.io/$(echo $GITHUB_REPOSITORY | sed 's/docker-//g') .
+        run: DOCKER_BUILDKIT=1 docker build -t ghcr.io/$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]' | sed 's/docker-//g') .

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,8 +86,7 @@ RUN set -eux ; \
       zlib \
       diffutils \
       krb5-workstation \
-      fuse \
-      openssl ; \
+      fuse ; \
     yum clean all
 RUN sudo python3 -m pip install --upgrade pip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,8 @@ RUN set -eux ; \
       zlib \
       diffutils \
       krb5-workstation \
-      fuse ; \
+      fuse \
+      openssl ; \
     yum clean all
 RUN sudo python3 -m pip install --upgrade pip
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ubuntu 18.04 runners no longer exist, upgrading them to ubuntu-latest should fix this issue.

## What is the link to the Apache JIRA

[HDDS-8523](https://issues.apache.org/jira/browse/HDDS-8523)

## How was this patch tested?
There is a cross-blocking issue here where the automatic workflow won't run with ubuntu 18.04 version because github runners no longer use it, but I can't fix that problem until this issue is fixed.

An example of a workflow run where both issues have been fixed and it worked properly:
https://github.com/Galsza/ozone-docker-runner/actions/runs/4870673262

