### PR TITLE
HDDS-8524. Allow workflow runs for repositories with uppercase characters in them.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,4 +24,4 @@ jobs:
       - name: checkout source
         uses: actions/checkout@v2
       - name: build image
-        run: DOCKER_BUILDKIT=1 docker build -t ghcr.io/$(echo $GITHUB_REPOSITORY | sed 's/docker-//g') .
+        run: DOCKER_BUILDKIT=1 docker build -t ghcr.io/$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]' | sed 's/docker-//g') .


### PR DESCRIPTION
## What changes were proposed in this pull request?

Docker run command expects lowercase arguments and when a repository contains uppercase letters the workflow run fails.

## What is the link to the Apache JIRA

[HDDS-8524](https://issues.apache.org/jira/browse/HDDS-8524)

## How was this patch tested?

There is a cross-blocking issue here where the automatic workflow won't run with ubuntu 18.04 version because github runners no longer use it, but I can't fix that problem until this issue is fixed.

An example of a workflow run where both issues have been fixed and it worked properly:
https://github.com/Galsza/ozone-docker-runner/actions/runs/4870673262