### PR TITLE
HDDS-8628. Install lsof and netstat in ozone-runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,12 +37,12 @@ FROM centos:7.9.2009 AS builder
 RUN yum -y install epel-release centos-release-scl
 RUN set -eux ; \
     yum -y install \
+      cmake3 \
       devtoolset-10-gcc-c++ \
       make \
+      perl \
       which \
-      cmake3 \
-      perl ; \
-    yum clean all
+    && yum clean all
 RUN ln -s /usr/bin/cmake3 /usr/bin/cmake
 # Add gcc 10 bin path
 ENV PATH=/opt/rh/devtoolset-10/root/usr/bin:$PATH
@@ -77,18 +77,18 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 RUN set -eux ; \
     yum install -y \
       bzip2 \
+      diffutils \
+      fuse \
       java-11-openjdk-devel \
       jq \
+      krb5-workstation \
       nmap-ncat \
       openssl \
       python3 python3-pip \
       snappy \
       sudo \
       zlib \
-      diffutils \
-      krb5-workstation \
-      fuse ; \
-    yum clean all
+    && yum clean all
 RUN sudo python3 -m pip install --upgrade pip
 
 COPY --from=go /go/bin/csc /usr/bin/csc

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,8 @@ RUN set -eux ; \
       java-11-openjdk-devel \
       jq \
       krb5-workstation \
+      lsof \
+      net-tools \
       nmap-ncat \
       openssl \
       python3 python3-pip \


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Install `lsof` and `netstat` to help checking network connections
* Sort packages in `yum install` command in the Dockerfile

https://issues.apache.org/jira/browse/HDDS-8628

## How was this patch tested?

https://github.com/adoroszlai/ozone-docker-runner/actions/runs/4983558872/jobs/8920739570#step:3:1161