### PR TITLE
HDDS-8843. Bump up rocksdb version in Ozone docker runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN export ZSTD_VER=1.5.2 \
       && make install \
       && cd .. \
       && rm -r zstd-${ZSTD_VER}
-RUN export ROCKSDB_VER=7.0.4 \
+RUN export ROCKSDB_VER=7.7.3 \
       && curl -LSs https://github.com/facebook/rocksdb/archive/v${ROCKSDB_VER}.tar.gz | tar zxv \
       && mv rocksdb-${ROCKSDB_VER} rocksdb \
       && cd rocksdb \


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump up rocksdb version in Ozone docker runner

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8843


## How was this patch tested?
Building locally