### PR TITLE
HDDS-10199. Node.js 16 actions are deprecated

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: build image
         run: DOCKER_BUILDKIT=1 docker build -t ghcr.io/$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]' | sed 's/docker-//g') .


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade GitHub actions to `v4` to get Node.js 20.

https://issues.apache.org/jira/browse/HDDS-10199

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone-docker-runner/actions/runs/7644627140