### PR TITLE
HDDS-11143. Switch to Rocky Linux 8 as CentOS 7 is EOL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,7 @@ RUN set -eux ; \
     dnf install -y \
       bzip2 \
       diffutils \
+      findutils \
       fuse \
       jq \
       krb5-workstation \
@@ -96,7 +97,8 @@ RUN set -eux ; \
       snappy \
       sudo \
       zlib \
-    && dnf clean all
+    && dnf clean all \
+    && ln -sf /usr/bin/python3 /usr/bin/python
 RUN sudo python3 -m pip install --upgrade pip
 
 COPY --from=go /go/bin/csc /usr/bin/csc

--- a/Dockerfile
+++ b/Dockerfile
@@ -164,6 +164,9 @@ RUN set -eux ; \
     rm -f openjdk.tar.gz
 
 ENV JAVA_HOME=/usr/local/jdk-17.0.2
+# compatibility with Ozone 1.4.0 and earlier compose env.
+RUN mkdir -p /usr/lib/jvm && ln -s $JAVA_HOME /usr/lib/jvm/jre
+
 ENV LD_LIBRARY_PATH=/usr/local/lib
 ENV PATH=/opt/hadoop/libexec:$PATH:$JAVA_HOME/bin:/opt/hadoop/bin
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

CentOS 7 has reached EOL on June 30th, Need to adopt alternative Open source Linux Distros.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11143

## How was this patch tested?
Manually build the repo, works.
