### PR TITLE
HDDS-11165. Install ps in ozone-runner image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,7 @@ RUN set -eux ; \
       net-tools \
       nmap-ncat \
       openssl \
+      procps \
       python3 python3-pip \
       snappy \
       sudo \


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ps` is required for `compatibility` tests:

https://github.com/apache/ozone/blob/c05227a0dc1ba833383ece7379d8a1e977c5bb45/hadoop-ozone/dist/src/main/smoketest/lib/os.robot#L66C1-L67C1

but it's missing from the new Rocky Linux-based image `20240712-jdk17-1`:

`/bin/sh: ps: command not found`

https://issues.apache.org/jira/browse/HDDS-11165

## How was this patch tested?

```
$ docker build -t ozone-runner:dev .
...

$ docker run -it --rm ozone-runner:dev ps
To use Ozone please mount ozone folder to /opt/hadoop
    PID TTY          TIME CMD
      7 pts/0    00:00:00 ps
```