### PR TITLE
HDDS-11203. Autolink Ozone Jira issues

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,6 +18,8 @@ github:
   labels:
     - ozone
     - container
+  autolink_jira:
+    - HDDS
   enabled_merge_buttons:
     squash:  true
     merge:   false


### PR DESCRIPTION
## What changes were proposed in this pull request?

Automatically link HDDS issues from GitHub to Jira.

https://issues.apache.org/jira/browse/HDDS-11203

## How was this patch tested?

Similar `.asf.yaml` change tested in other repos:
- https://github.com/apache/ozone/commit/d793e93550
- https://github.com/apache/ratis/commit/0814b896