### PR TITLE
HDDS-11111. Create ozone-runner base image for Java 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,17 +95,13 @@ RUN set -eux ; \
     curl -L ${url} | tar xvz ; \
     mv async-profiler-* /opt/profiler
 
-# OpenJDK 17
+# OpenJDK 11
 RUN set -eux ; \
     ARCH="$(arch)"; \
     case "${ARCH}" in \
         x86_64) \
-            url='https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_linux-x64_bin.tar.gz'; \
-            sha256='0022753d0cceecacdd3a795dd4cea2bd7ffdf9dc06e22ffd1be98411742fbb44'; \
-            ;; \
-        aarch64) \
-            url='https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_linux-aarch64_bin.tar.gz'; \
-            sha256='13bfd976acf8803f862e82c7113fb0e9311ca5458b1decaef8a09ffd91119fa4'; \
+            url='https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz'; \
+            sha256='99be79935354f5c0df1ad293620ea36d13f48ec3ea870c838f20c504c9668b57'; \
             ;; \
         *) echo "Unsupported architecture: ${ARCH}"; exit 1 ;; \
     esac && \
@@ -114,7 +110,7 @@ RUN set -eux ; \
     tar xzvf openjdk.tar.gz -C /usr/local && \
     rm -f openjdk.tar.gz
 
-ENV JAVA_HOME=/usr/local/jdk-17.0.2
+ENV JAVA_HOME=/usr/local/jdk-11.0.2
 # compatibility with Ozone 1.4.0 and earlier compose env.
 RUN mkdir -p /usr/lib/jvm && ln -s $JAVA_HOME /usr/lib/jvm/jre
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Current `ozone-runner` comes with JDK 17 (HDDS-8247).

Existing `ozone` images (up to 1.4.0) ship with some outdated software that we'd like to upgrade (e.g. Robot Framework).  However, those Ozone versions do not work with JDK 17.

So we should create `ozone-runner` image with up-to-date software, but with JDK 11 (like before HDDS-8247), in addition to the newer JDK version(s).

https://issues.apache.org/jira/browse/HDDS-11111

## How was this patch tested?

Built locally, verified Java version.

```
$ docker builder build -t apache/ozone-runner:HDDS-11111 .
...

$ docker run -it --rm apache/ozone-runner:HDDS-11111 java -version
To use Ozone please mount ozone folder to /opt/hadoop
openjdk version "11.0.2" 2019-01-15
OpenJDK Runtime Environment 18.9 (build 11.0.2+9)
OpenJDK 64-Bit Server VM 18.9 (build 11.0.2+9, mixed mode)
```

CI:
https://github.com/adoroszlai/ozone-docker-runner/actions/runs/10421915621/job/28865235225