### PR TITLE
HDDS-11602. Install ncurses to get the tput command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN set -eux ; \
       jq \
       krb5-workstation \
       lsof \
+      ncurses \
       net-tools \
       nmap-ncat \
       openssl \
@@ -50,7 +51,6 @@ RUN set -eux ; \
       snappy \
       sudo \
       zlib \
-      ncurses \
     && dnf clean all \
     && ln -sf /usr/bin/python3 /usr/bin/python
 RUN sudo python3 -m pip install --upgrade pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ RUN set -eux ; \
       snappy \
       sudo \
       zlib \
+      ncurses \
     && dnf clean all \
     && ln -sf /usr/bin/python3 /usr/bin/python
 RUN sudo python3 -m pip install --upgrade pip


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `ozone` command shows a `tput: command not found` error
```bash
rpatel@Rishabhs-MacBook-Pro ozone % docker-compose exec scm bash
bash-4.4$ ozone
Usage: ozone [OPTIONS] SUBCOMMAND [SUBCOMMAND OPTIONS]

  OPTIONS is none or any of:

/opt/hadoop/bin/../libexec/ozone-functions.sh: line 413: tput: command not found
--buildpaths                       attempt to add class files from build tree
--config dir                       Ozone config directory
```
 
The `tput` command is not available
```bash
bash-4.4$ tput
bash: tput: command not found


bash-4.4$ dnf list installed | grep ncurses
ncurses-base.noarch                6.1-10.20180224.el8                    @System   
ncurses-libs.x86_64                6.1-10.20180224.el8                    @System   
```

Installing the ncurses package fixes the problem
```
bash-4.4$ sudo dnf install ncurses
Rocky Linux 8 - AppStream                                                                                                                                     7.1 MB/s |  13 MB     00:01    
Rocky Linux 8 - BaseOS                                                                                                                                        5.2 MB/s | 7.3 MB     00:01    
Rocky Linux 8 - Extras                                                                                                                                         32 kB/s |  14 kB     00:00    
Dependencies resolved.
==============================================================================================================================================================================================
 Package                                    Architecture                              Version                                                 Repository                                 Size
==============================================================================================================================================================================================
Installing:
 ncurses                                    x86_64                                    6.1-10.20180224.el8                                     baseos                                    386 k

Transaction Summary
==============================================================================================================================================================================================
Install  1 Package

Total download size: 386 k
Installed size: 575 k
Is this ok [y/N]: y
Downloading Packages:
ncurses-6.1-10.20180224.el8.x86_64.rpm                                                                                                                        601 kB/s | 386 kB     00:00    
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Total                                                                                                                                                         507 kB/s | 386 kB     00:00     
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                                      1/1 
  Installing       : ncurses-6.1-10.20180224.el8.x86_64                                                                                                                                   1/1 
  Running scriptlet: ncurses-6.1-10.20180224.el8.x86_64                                                                                                                                   1/1 
  Verifying        : ncurses-6.1-10.20180224.el8.x86_64                                                                                                                                   1/1 

Installed:
  ncurses-6.1-10.20180224.el8.x86_64                                                                                                                                                          

Complete!
```
```bash

bash-4.4$ tput
Usage: tput [options] [command]

Options:
  -S <<       read commands from standard input
  -T TERM     use this instead of $TERM
  -V          print curses-version
  -x          do not try to clear scrollback

Commands:
  clear       clear the screen
  init        initialize the terminal
  reset       reinitialize the terminal
  capname     unlike clear/init/reset, print value for capability "capname"
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11602

## How was this patch tested?

This patch was manually tested
The `ozone` cli no longer throws the `tput: command not found` error
```bash
bash-4.4$ ozone
Usage: ozone [OPTIONS] SUBCOMMAND [SUBCOMMAND OPTIONS]

  OPTIONS is none or any of:

--buildpaths                       attempt to add class files from build tree
--config dir                       Ozone config directory
```