### PR TITLE
HDDS-11639. Upgrade ozone-runner to Rocky Linux 9.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN set -eux ; \
         exit 1 ; \
     fi
 
-FROM rockylinux:8.9
+FROM rockylinux:9.3
 RUN set -eux ; \
     dnf install -y \
       bzip2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ COPY --from=go /go/bin/csc /usr/bin/csc
 
 #For executing inline smoketest
 RUN set -eux ; \
-    pip3 install awscli robotframework boto3 ; \
+    pip3 install awscli robotframework==6.1.1 boto3 ; \
     rm -r ~/.cache/pip
 
 #dumb init for proper init handling


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade Rocky Linux from 8.9 to 9.3 in `ozone-runner` image.

https://issues.apache.org/jira/browse/HDDS-11639

## How was this patch tested?

Pushed image to GitHub:
https://github.com/adoroszlai/ozone-docker-runner/pkgs/container/ozone-runner/299778774?tag=45de37522f47eb78f6cd5a4a125bd3f5b8d6f169

tested with Ozone CI:
https://github.com/adoroszlai/ozone/actions/runs/11662926001