### PR TITLE
HDDS-8569. Build and publish ozone-runner for linux/arm64

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,6 +62,14 @@ jobs:
 
           echo "success=$success" >> $GITHUB_OUTPUT
 
+      - name: Set up QEMU
+        if: ${{ steps.pull.outputs.success == 'false' }}
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        if: ${{ steps.pull.outputs.success == 'false' }}
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to GitHub Container Registry
         id: login
         if: ${{ github.event_name != 'pull_request' && steps.pull.outputs.success == 'false' }}
@@ -76,7 +84,7 @@ jobs:
         if: ${{ steps.pull.outputs.success == 'false' }}
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75
         with:
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,11 +64,11 @@ jobs:
 
       - name: Set up QEMU
         if: ${{ steps.pull.outputs.success == 'false' }}
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf
 
       - name: Set up Docker Buildx
         if: ${{ steps.pull.outputs.success == 'false' }}
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349
 
       - name: Login to GitHub Container Registry
         id: login


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add steps to build multi-platform `ozone-runner` images with `linux/amd64` and `linux/arm64`.

https://issues.apache.org/jira/browse/HDDS-8569

## How was this patch tested?

Verified that the [image](https://github.com/adoroszlai/ozone-docker-runner/pkgs/container/ozone-runner/301713930?tag=07b14f6d4a4861971054865fa683559f67a7e4cf) built on `push` of this branch to my fork has both architectures.