### PR TITLE
HDDS-11634. Publish images to Docker Hub from GitHub workflow

### DIFF
--- a/.github/workflows/build-and-tag.yaml
+++ b/.github/workflows/build-and-tag.yaml
@@ -33,17 +33,24 @@ jobs:
     if: ${{ github.ref_type == 'tag' }}
     runs-on: ubuntu-latest
     env:
+      DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
       IMAGE_ID: ${{ needs.build.outputs.image-id }}
+      REGISTRIES: ghcr.io # docker.io is appended dynamically
     steps:
       - name: Generate tags
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
         with:
           images: |
-            ghcr.io/${{ github.repository_owner }}/ozone-runner
+            ${{ github.repository_owner }}/ozone-runner
           tags: |
             type=ref,event=tag
           flavor: |
             latest=false
+
+      - name: Add Docker Hub to targets
+        if: ${{ env.DOCKERHUB_USER }}
+        run: |
+          echo "REGISTRIES=${{ env.REGISTRIES}} docker.io" >> $GITHUB_ENV
 
       - name: Pull image
         run: |
@@ -56,9 +63,18 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_USER }}
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        with:
+          username: ${{ env.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Apply tags to existing image
         run: |
-          for tag in $DOCKER_METADATA_OUTPUT_TAGS; do
-            docker tag "$IMAGE_ID" "$tag"
-            docker push "$tag"
+          for registry in $REGISTRIES; do
+            for tag in $DOCKER_METADATA_OUTPUT_TAGS; do
+              docker tag "$IMAGE_ID" "$registry/$tag"
+              docker push "$registry/$tag"
+            done
           done

--- a/.github/workflows/build-and-tag.yaml
+++ b/.github/workflows/build-and-tag.yaml
@@ -72,9 +72,10 @@ jobs:
 
       - name: Apply tags to existing image
         run: |
+          set -x
           for registry in $REGISTRIES; do
-            for tag in $DOCKER_METADATA_OUTPUT_TAGS; do
-              docker tag "$IMAGE_ID" "$registry/$tag"
-              docker push "$registry/$tag"
-            done
+            opts="$(echo "$DOCKER_METADATA_OUTPUT_TAGS" | sed "s@^@--tag $registry/@g" | xargs echo)"
+            if [[ -n "$opts" ]]; then
+              docker buildx imagetools create $opts "$IMAGE_ID"
+            fi
           done

--- a/.github/workflows/build-and-tag.yaml
+++ b/.github/workflows/build-and-tag.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Add Docker Hub to targets
         if: ${{ env.DOCKERHUB_USER }}
         run: |
-          echo "REGISTRIES=${{ env.REGISTRIES}} docker.io" >> $GITHUB_ENV
+          echo "REGISTRIES=${{ env.REGISTRIES }} docker.io" >> $GITHUB_ENV
 
       - name: Pull image
         run: |


### PR DESCRIPTION
## What changes were proposed in this pull request?

Publish `ozone-runner` Docker images created by the CI workflow to Docker Hub, in addition to existing practice.

Only publish images with tags, not by Git commit SHA (the latter is used only for GitHub Container Registry).

Publishing to Docker Hub is optional, only done if the secrets are defined for the repo.  This way the workflow is still functional in forks whose owners have not set up Docker Hub repository.  ([Example run](https://github.com/adoroszlai/ozone-docker-runner/actions/runs/11708712290/job/32611216489) before I set up secrets in my fork.)

https://issues.apache.org/jira/browse/HDDS-11634

## How was this patch tested?

```
git tag test-HDDS-11634
git push adoroszlai test-HDDS-11634
```

[Workflow](https://github.com/adoroszlai/ozone-docker-runner/actions/runs/11720643164/job/32646418482) published the image to both [GitHub](https://github.com/adoroszlai/ozone-docker-runner/pkgs/container/ozone-runner/301804159?tag=test-HDDS-11634) and [Docker Hub](https://hub.docker.com/layers/adoroszlai/ozone-runner/test-HDDS-11634/images/sha256-4f8b2ab305a3fbc3f4602f5f7dc2f9a76c8c6659b610a806c8391b1398580802?context=explore).

Secrets set by Apache Infra on this repo will be tested when this is merged and the commit tagged.

Once we confirm this to be working, we can ask Infra to disable the Docker Hub automated build.