### PR TITLE
HDDS-8569. Build ozone-runner with JDK 11 for arm64

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,6 +62,14 @@ jobs:
 
           echo "success=$success" >> $GITHUB_OUTPUT
 
+      - name: Set up QEMU
+        if: ${{ steps.pull.outputs.success == 'false' }}
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf
+
+      - name: Set up Docker Buildx
+        if: ${{ steps.pull.outputs.success == 'false' }}
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349
+
       - name: Login to GitHub Container Registry
         id: login
         if: ${{ github.event_name != 'pull_request' && steps.pull.outputs.success == 'false' }}
@@ -76,7 +84,7 @@ jobs:
         if: ${{ steps.pull.outputs.success == 'false' }}
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75
         with:
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN set -eux ; \
       diffutils \
       findutils \
       fuse \
+      java-11-openjdk-devel \
       jq \
       krb5-workstation \
       lsof \
@@ -96,27 +97,10 @@ RUN set -eux ; \
     curl -L ${url} | tar xvz ; \
     mv async-profiler-* /opt/profiler
 
-# OpenJDK 11
-RUN set -eux ; \
-    ARCH="$(arch)"; \
-    case "${ARCH}" in \
-        x86_64) \
-            url='https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz'; \
-            sha256='99be79935354f5c0df1ad293620ea36d13f48ec3ea870c838f20c504c9668b57'; \
-            ;; \
-        *) echo "Unsupported architecture: ${ARCH}"; exit 1 ;; \
-    esac && \
-    curl -L ${url} -o openjdk.tar.gz && \
-    echo "${sha256} *openjdk.tar.gz" | sha256sum -c - && \
-    tar xzvf openjdk.tar.gz -C /usr/local && \
-    rm -f openjdk.tar.gz
-
-ENV JAVA_HOME=/usr/local/jdk-11.0.2
-# compatibility with Ozone 1.4.0 and earlier compose env.
-RUN mkdir -p /usr/lib/jvm && ln -s $JAVA_HOME /usr/lib/jvm/jre
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk
 
 ENV LD_LIBRARY_PATH=/usr/local/lib
-ENV PATH=/opt/hadoop/libexec:$PATH:$JAVA_HOME/bin:/opt/hadoop/bin
+ENV PATH=/opt/hadoop/libexec:$PATH:/opt/hadoop/bin
 
 RUN id=1000; \
     for u in hadoop om dn scm s3g recon testuser testuser2 httpfs; do \


### PR DESCRIPTION
## What changes were proposed in this pull request?

JDK 11 is not available for aarch64 from https://jdk.java.net/archive/, but we can install it from OS package.  This allows building multi-arch images for Ozone releases before 1.4.0.

https://issues.apache.org/jira/browse/HDDS-8569

## How was this patch tested?

workflow run: https://github.com/adoroszlai/ozone-docker-runner/actions/runs/11939244167/job/33279343409
image: https://github.com/adoroszlai/ozone-docker-runner/pkgs/container/ozone-runner/309268740?tag=9f2a72c80cfbb98b42ef002cd63b07d65f469024

Built Ozone 1.3.0 image with slightly modified Dockerfile:

```
$ docker build --progress plain --build-arg OZONE_RUNNER_IMAGE=ghcr.io/adoroszlai/ozone-runner --build-arg OZONE_RUNNER_VERSION=9f2a72c80cfbb98b42ef002cd63b07d65f469024 .
...
#15 writing image sha256:70e68065fcf5a71e7e49bcf7c74b7582128122e2eccbc6778f749002b04c8c26 done

$ docker run -it --rm 70e68065fcf5a71e7e49bcf7c74b7582128122e2eccbc6778f749002b04c8c26 ozone version
...
              /    1.3.0(Grand Canyon)
...

$ docker run -it --rm 70e68065fcf5a71e7e49bcf7c74b7582128122e2eccbc6778f749002b04c8c26 java -version
openjdk version "11.0.25" 2024-10-15 LTS
OpenJDK Runtime Environment (Red_Hat-11.0.25.0.9-1) (build 11.0.25+9-LTS)
OpenJDK 64-Bit Server VM (Red_Hat-11.0.25.0.9-1) (build 11.0.25+9-LTS, mixed mode, sharing)
```