### PR TITLE
HDDS-11915. Netty OpenSsl not available on arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN set -eux ; \
       fuse \
       jq \
       krb5-workstation \
+      libxcrypt-compat \
       lsof \
       ncurses \
       net-tools \


### PR DESCRIPTION
## What changes were proposed in this pull request?

Netty OpenSsl is not available on arm64:

```
UnsatisfiedLinkError: /tmp/liborg_apache_ratis_thirdparty_netty_tcnative_linux_aarch_6412907517136400085340.so: libcrypt.so.1: cannot open shared object file: No such file or directory
```

Install `libxcrypt-compat` explicitly to fix it.  ([Previously](https://github.com/apache/ozone-docker-runner/actions/runs/11912936417/job/33197580773#step:7:407) it was automatically installed as dependency on amd64, but not on arm64.)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11915

## How was this patch tested?

Tested the image built on push to my fork:

```
$ docker run -it --rm -v ~/.m2:/opt/hadoop/.m2 \
  ghcr.io/adoroszlai/ozone-runner:052dedfe508e9ea459824846d7c8ee317fb47ef9 \
  bash -c "echo 'org.apache.ratis.thirdparty.io.netty.handler.ssl.OpenSsl.isAvailable()' | jshell --class-path ~/.m2/repository/org/apache/ratis/ratis-thirdparty-misc/1.0.6/ratis-thirdparty-misc-1.0.6.jar"
...

jshell> org.apache.ratis.thirdparty.io.netty.handler.ssl.OpenSsl.isAvailable()$1 ==> true
```