### PR TITLE
HDDS-5045. Add rclone package for robot test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,11 @@ RUN sudo python3 -m pip install --upgrade pip
 
 COPY --from=go /go/bin/csc /usr/bin/csc
 
+RUN dnf install -y unzip \
+    && curl https://rclone.org/install.sh | sudo bash \
+    && dnf remove -y unzip \
+    && dnf clean all
+
 #For executing inline smoketest
 RUN set -eux ; \
     pip3 install awscli robotframework==6.1.1 boto3 ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,10 +58,18 @@ RUN sudo python3 -m pip install --upgrade pip
 
 COPY --from=go /go/bin/csc /usr/bin/csc
 
-RUN dnf install -y unzip \
-    && curl https://rclone.org/install.sh | sudo bash \
-    && dnf remove -y unzip \
-    && dnf clean all
+# Install rclone for smoketest
+RUN set -eux ; \
+    ARCH="$(arch)" ; \
+    case "${ARCH}" in \
+        x86_64)  url='https://downloads.rclone.org/rclone-current-linux-amd64.rpm' ;; \
+        aarch64) url='https://downloads.rclone.org/rclone-current-linux-arm64.rpm' ;; \
+        *) echo "Unsupported architecture: ${ARCH}"; exit 1 ;; \
+    esac; \
+    curl -L -o /tmp/package.rpm "${url}"; \
+    dnf install -y /tmp/package.rpm; \
+    rm -f /tmp/package.rpm
+
 
 #For executing inline smoketest
 RUN set -eux ; \


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds the [rclone tool](https://rclone.org/s3/) needed for robot tests

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5045

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?
CI: https://github.com/ptlrs/ozone-docker-runner/actions/runs/12306659392
Manually built and ran the dev image