### PR TITLE
HDDS-12359. Bump async profiler to 2.9, awscli to 1.37

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,8 +103,8 @@ RUN curl -Lo /opt/byteman.jar https://repo.maven.apache.org/maven2/org/jboss/byt
 RUN set -eux ; \
     ARCH="$(arch)" ; \
     case "${ARCH}" in \
-        x86_64)  url='https://github.com/jvm-profiling-tools/async-profiler/releases/download/v2.7/async-profiler-2.7-linux-x64.tar.gz' ;; \
-        aarch64) url='https://github.com/jvm-profiling-tools/async-profiler/releases/download/v2.7/async-profiler-2.7-linux-arm64.tar.gz' ;; \
+        x86_64)  url='https://github.com/jvm-profiling-tools/async-profiler/releases/download/v2.9/async-profiler-2.9-linux-x64.tar.gz' ;; \
+        aarch64) url='https://github.com/jvm-profiling-tools/async-profiler/releases/download/v2.9/async-profiler-2.9-linux-arm64.tar.gz' ;; \
         *) echo "Unsupported architecture: ${ARCH}"; exit 1 ;; \
     esac; \
     curl -L ${url} | tar xvz ; \


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump dependencies:
- async profiler 2.9
- awscli 1.37 (latest version)

https://issues.apache.org/jira/browse/HDDS-12359

## How was this patch tested?

```
#20 7.998 Successfully installed PyYAML-6.0.2 awscli-1.37.21 boto3-1.36.21 botocore-1.36.21 colorama-0.4.6 docutils-0.16 jmespath-1.0.1 pyasn1-0.6.1 python-dateutil-2.9.0.post0 robotframework-6.1.1 rsa-4.7.2 s3transfer-0.11.2 six-1.17.0 urllib3-1.26.20
...
#23 0.390 + mv async-profiler-2.9-linux-x64 /opt/profiler
```

https://github.com/adoroszlai/ozone-docker-runner/actions/runs/13377374876/job/37359340791#step:7:1137
