### PR TITLE
HDDS-12441. Add helper script for building Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.asf.yaml
+build.sh
+CONTRIBUTING.md
+.git
+.github
+LICENSE
+NOTICE
+README.md
+SECURITY.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,11 +62,7 @@ To run complete Ozone CI with the custom image:
 3. Update `docker.ozone-runner.version` to `<commit SHA>` in [hadoop-ozone/dist/pom.xml](https://github.com/apache/ozone/blob/bb16f66e22c44b360d42d0cae87024786e27c61b/hadoop-ozone/dist/pom.xml#L28).
 4. Commit the change and push to your fork of `apache/ozone`.
 
-## Tagging
-
-(for committers)
-
-Publishing Docker tags:
+## Publishing Docker Tags (for committers)
 
 1. Fetch changes to your local clone.
 2. Add a Git tag for the commit following the existing pattern `<date>-<n>-<flavor>`, where

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,83 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
 # Contributing
 
-For detailed contribution guideline, please check the [contribution guideline of Apache Ozone repository](https://github.com/apache/ozone/blob/master/CONTRIBUTING.md).
+For general contribution guideline, please check the [Apache Ozone repository](https://github.com/apache/ozone/blob/master/CONTRIBUTING.md).
 
+Development of the `ozone-runner` image happens on branch `master`, relevant changes are cherry-picked to branch `jdk11`.
+
+## Local Build and Test
+
+### Building
+
+The image can be built simply by running the helper script `build.sh`:
+
+```bash
+$ ./build.sh
+...
+ => => naming to docker.io/apache/ozone-runner:dev
+```
+
+### Testing
+
+To try the image locally with Ozone acceptance tests, define the version to be used:
+
+```bash
+export OZONE_RUNNER_VERSION=dev
+```
+
+then run [acceptance tests](https://github.com/apache/ozone/blob/master/hadoop-ozone/dist/src/main/compose/README.md) as needed.
+
+## GitHub Workflows
+
+If this is your first time working on the image, please enable GitHub Actions workflows after forking the repo.
+
+### Building
+
+CI checks are triggered by pushing changes to your fork.
+
+GitHub Actions workflow runs in your fork are listed at `https://github.com/<username>/ozone-docker-runner/actions`.
+
+The image is built and tagged with commit SHA in GitHub, ready for testing integration with other repos.
+
+Images built in your fork are available at `https://github.com/<username>/ozone-docker-runner/pkgs/container/ozone-runner`.
+
+These images can be shared with other developers for feedback.
+
+### Testing
+
+To run complete Ozone CI with the custom image:
+
+1. Create a new branch in your clone of `apache/ozone`.
+2. Update `OZONE_RUNNER_IMAGE` to `ghrc.io/<username>/ozone-runner` in [ci.yml](https://github.com/apache/ozone/blob/bb16f66e22c44b360d42d0cae87024786e27c61b/.github/workflows/ci.yml#L37).
+3. Update `docker.ozone-runner.version` to `<commit SHA>` in [hadoop-ozone/dist/pom.xml](https://github.com/apache/ozone/blob/bb16f66e22c44b360d42d0cae87024786e27c61b/hadoop-ozone/dist/pom.xml#L28).
+4. Commit the change and push to your fork of `apache/ozone`.
+
+## Tagging
+
+(for committers)
+
+Publishing Docker tags:
+
+1. Fetch changes to your local clone.
+2. Add a Git tag for the commit following the existing pattern `<date>-<n>-<flavor>`, where
+   - `<n>` starts at 1, and is incremented if multiple images need to be published the same day)
+   - `<flavor>` is `jdk21` or `jdk11`
+3. Push the Git tag to the official repo (`apache/ozone-docker-runner`).  This will trigger a workflow to apply the tag to the Docker image.
+4. If the change is relevant for Ozone 1.x versions, cherry-pick it to the `jdk11` branch.
+5. Set `Fix Version` of the Jira issue to `runner-<date>-<n>-<flavor>`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,8 @@ $ ./build.sh
  => => naming to docker.io/apache/ozone-runner:dev
 ```
 
+This will create a single-platform image for your architecture.
+
 ### Testing
 
 To try the image locally with Ozone acceptance tests, define the version to be used:
@@ -49,15 +51,7 @@ If this is your first time working on the image, please enable GitHub Actions wo
 
 ### Building
 
-CI checks are triggered by pushing changes to your fork.
-
-GitHub Actions workflow runs in your fork are listed at `https://github.com/<username>/ozone-docker-runner/actions`.
-
-The image is built and tagged with commit SHA in GitHub, ready for testing integration with other repos.
-
-Images built in your fork are available at `https://github.com/<username>/ozone-docker-runner/pkgs/container/ozone-runner`.
-
-These images can be shared with other developers for feedback.
+Whenever changes are pushed to your fork, GitHub builds a multi-platform image (for `amd64` and `arm64`), and tags it with the commit SHA.  These images can be shared with other developers for feedback.  Workflow runs are listed at `https://github.com/<username>/ozone-docker-runner/actions`, images at `https://github.com/<username>/ozone-docker-runner/pkgs/container/ozone-runner`.
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -15,47 +15,10 @@
   limitations under the License.
 -->
 
-# Apache Ozone **runner** base image
+# Apache Ozone Runner Base Image
 
-This is the base image to run Apache Hadoop Ozone in docker containers. This is only for test/develop and not for production.
+[ozone-runner](https://github.com/apache/ozone-docker-runner) is the base image with tools for running and testing Apache Ozone, but does not include any Ozone artifacts.
 
-The container doesn't include any Ozone specific jar files or release artifacts just an empty environment which includes all the specific tools to run and test Apache Ozone inside containers.
+Published to [Docker Hub](https://hub.docker.com/r/apache/ozone-runner) and [GitHub](https://github.com/apache/ozone-docker-runner/pkgs/container/ozone-runner).
 
-The image is available as [apache/ozone-runner](https://hub.docker.com/r/apache/ozone-runner). Build is managed by Docker Hub.
-
-## Development
-
-To build the image, please use:
-
-```
-DOCKER_BUILDKIT=1 docker build -t apache/ozone-runner:dev .
-```
-
-To test it, build [Apache Ozone](https://github.com/apache/ozone):
-
-```
-mvn clean verify -DskipTests -Dskip.npx -DskipShade -Ddocker.ozone-runner.version=dev
-```
-
-And start the compose cluster:
-
-```
-cd hadoop-ozone/dist/target/ozone-*/compose/ozone
-docker-compose up -d
-```
-
-*After merging PR, a new tag should pushed to the repository to create a new image. Use the convention: `YYYYMMDD-N` for tags where N is a daily counter (see the existing tags as an example).
-
-After tag is published (and built by Docker Hub), the used runner version can be updated by modifying the `docker.ozone-runner.version` version in [hadoop-ozone/dist/pom.xml](https://github.com/apache/ozone/blob/master/hadoop-ozone/dist/pom.xml)
-
-## Building multi-architecture images
-
-To build images with multiple architectures, use `docker buildx`.
-
-For example, to build images for both `linux/amd64` and `linux/arm64`, run:
-
-```bash
-docker buildx build --platform linux/amd64,linux/arm64 -t apache/ozone-runner:dev . --progress=plain
-```
-
-It might be slow when building the non-native architecture image due to QEMU emulation.
+Images are tagged by date, and come in two flavors: `jdk21` (for Ozone 2.0+) and `jdk11` (for Ozone 1.x).

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu -o pipefail
+
+docker build -t apache/ozone-runner:dev "$@" .


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `build.sh`, helper script for building the image.

Benefits:

- consistent experience across `ozone-docker*` repos
- future improvements possible without updating docs

Also add `.dockerignore`.

https://issues.apache.org/jira/browse/HDDS-12441

## How was this patch tested?

```bash
$ ./build.sh
...
 => => naming to docker.io/apache/ozone-runner:dev
```

CI:
https://github.com/adoroszlai/ozone-docker-runner/actions/runs/13583576812