### PR TITLE
HDDS-12467. Enable new asf.yaml parser

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -12,6 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# Enable the next-gen .asf.yaml parser
+meta:
+  nextgen: true
+
 github:
   description: "Container image to provide runtime environment for developing and testing Apache Ozone"
   homepage: https://ozone.apache.org


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enable new asf.yaml parser.  This needs to be committed separately before we can start using it for configuration.

https://issues.apache.org/jira/browse/HDDS-12467

## How was this patch tested?

Tested same change in other repo (https://github.com/apache/ozone-docker-testkrb5/pull/12).