### PR TITLE
HDDS-12631. Correct LD_LIBRARY_PATH for ozone-runner Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -133,7 +133,7 @@ ENV JAVA_HOME=/usr/local/jdk-21.0.2
 # compatibility with Ozone 1.4.0 and earlier compose env.
 RUN mkdir -p /usr/lib/jvm && ln -s $JAVA_HOME /usr/lib/jvm/jre
 
-ENV LD_LIBRARY_PATH=/usr/local/lib
+ENV LD_LIBRARY_PATH=/usr/local/lib:/lib64/:/usr/lib64
 ENV PATH=/opt/hadoop/libexec:$PATH:$JAVA_HOME/bin:/opt/hadoop/bin
 
 RUN id=1000; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -133,7 +133,6 @@ ENV JAVA_HOME=/usr/local/jdk-21.0.2
 # compatibility with Ozone 1.4.0 and earlier compose env.
 RUN mkdir -p /usr/lib/jvm && ln -s $JAVA_HOME /usr/lib/jvm/jre
 
-ENV LD_LIBRARY_PATH=/usr/local/lib:/lib64/:/usr/lib64
 ENV PATH=/opt/hadoop/libexec:$PATH:$JAVA_HOME/bin:/opt/hadoop/bin
 
 RUN id=1000; \


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-12631. Correct LD_LIBRARY_PATH for ozone-runner Docker image


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12631

## How was this patch tested?

built a dev ozone-docker-runner image, and built a dev ozone-docker image. Loaded the tests and passed.