### PR TITLE
HDDS-12647. Update testing instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,8 +58,8 @@ Whenever changes are pushed to your fork, GitHub builds a multi-platform image (
 To run complete Ozone CI with the custom image:
 
 1. Create a new branch in your clone of `apache/ozone`.
-2. Update `OZONE_RUNNER_IMAGE` to `ghrc.io/<username>/ozone-runner` in [ci.yml](https://github.com/apache/ozone/blob/bb16f66e22c44b360d42d0cae87024786e27c61b/.github/workflows/ci.yml#L37).
-3. Update `docker.ozone-runner.version` to `<commit SHA>` in [hadoop-ozone/dist/pom.xml](https://github.com/apache/ozone/blob/bb16f66e22c44b360d42d0cae87024786e27c61b/hadoop-ozone/dist/pom.xml#L28).
+2. Update `OZONE_RUNNER_IMAGE` to `ghcr.io/<username>/ozone-runner` in [check.yml](https://github.com/apache/ozone/blob/23b0505d2ee27004f6e6c770de09e03853cf7643/.github/workflows/check.yml#L137).
+3. Update `docker.ozone-runner.version` to `<commit SHA>` in [hadoop-ozone/dist/pom.xml](https://github.com/apache/ozone/blob/23b0505d2ee27004f6e6c770de09e03853cf7643/hadoop-ozone/dist/pom.xml#L28).
 4. Commit the change and push to your fork of `apache/ozone`.
 
 ## Publishing Docker Tags (for committers)


### PR DESCRIPTION
## What changes were proposed in this pull request?

While testing [HDDS-12499](https://issues.apache.org/jira/browse/HDDS-12499), some deviations from the testing instructions in CONTRIBUTING.md were necessary to get a successful Ozone CI run. This PR proposes to make them official:

- Fix a trivial typo in the image reference.
- Update the instruction on changing the image reference, in line with [HDDS-11813](https://issues.apache.org/jira/browse/HDDS-11813) moving it to check.yml.
- Update the commit hash the pom.xml link points to. (Rationale: check.yml does not exist in the original commit, so that link has to be updated. This point restores consistency.)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12647

## How was this patch tested?

- CI: https://github.com/octachoron/ozone-docker-runner/actions/runs/13955519342
- Ozone CI run after following the testing instructions with the proposed changes: https://github.com/octachoron/ozone/actions/runs/13955751134