### PR TITLE
HDDS-12499. Install specific version of awscli and boto3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ RUN set -eux ; \
 
 #For executing inline smoketest
 RUN set -eux ; \
-    pip3 install awscli robotframework==6.1.1 boto3 ; \
+    pip3 install awscli==1.38.15 robotframework==6.1.1 boto3==1.37.15 ; \
     rm -r ~/.cache/pip
 
 #dumb init for proper init handling


### PR DESCRIPTION
## What changes were proposed in this pull request?

Instead of always installing the latest versions of awscli and boto3 into the images at build time, select specifically the latest versions as of the time this change was made. As noted on [HDDS-12499](https://issues.apache.org/jira/browse/HDDS-12499), this avoids unexpected version changes.

Both packages support Python 3.9, and their dependency declarations are compatible.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12499

## How was this patch tested?

- CI on fork: https://github.com/octachoron/ozone-docker-runner/actions/runs/13951576627
- Ozone CI with changed image: https://github.com/octachoron/ozone/actions/runs/13955751134
