### PR TITLE
HDDS-13333. Downgrade rclone to 1.69

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,14 +60,15 @@ RUN sudo python3 -m pip install --upgrade pip
 COPY --from=go /go/bin/csc /usr/bin/csc
 
 # Install rclone for smoketest
+ARG RCLONE_VERSION=1.69.3
 RUN set -eux ; \
     ARCH="$(arch)" ; \
     case "${ARCH}" in \
-        x86_64)  url='https://downloads.rclone.org/rclone-current-linux-amd64.rpm' ;; \
-        aarch64) url='https://downloads.rclone.org/rclone-current-linux-arm64.rpm' ;; \
+        x86_64)  arch='amd64' ;; \
+        aarch64) arch='arm64' ;; \
         *) echo "Unsupported architecture: ${ARCH}"; exit 1 ;; \
     esac; \
-    curl -L -o /tmp/package.rpm "${url}"; \
+    curl -L -o /tmp/package.rpm "https://downloads.rclone.org/v${RCLONE_VERSION}/rclone-v${RCLONE_VERSION}-linux-${arch}.rpm"; \
     dnf install -y /tmp/package.rpm; \
     rm -f /tmp/package.rpm
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Rclone Client Test fails with v1.70.1, included in ozone-runner 20250624-1-jdk21:

```
S3: PutObject, compute input header checksum failed, unseekable stream is not supported without TLS and trailing checksum
```

Install v1.69.3 instead of "latest".

https://issues.apache.org/jira/browse/HDDS-13333

## How was this patch tested?

```
$ ./build.sh
...
naming to docker.io/apache/ozone-runner:dev
```

Ran `s3/rclone.robot` in `ozonesecure` environment.

CI:
https://github.com/adoroszlai/ozone-docker-runner/actions/runs/15870072547