### PR TITLE
HDDS-13336. Set BYTEMAN_HOME in ozone-runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,17 +99,17 @@ RUN set -eux ; \
 
 #byteman test for development
 ARG BYTEMAN_VERSION=4.0.25
-ARG BYTEMAN_LIB=/opt/byteman/lib
-RUN curl -L -o /tmp/byteman.zip https://downloads.jboss.org/byteman/${BYTEMAN_VERSION}/byteman-download-${BYTEMAN_VERSION}-bin.zip && \
-    unzip /tmp/byteman.zip -d /tmp && \
-    sudo mkdir -p ${BYTEMAN_LIB} && \
-    sudo cp /tmp/byteman-download-${BYTEMAN_VERSION}/lib/byteman.jar ${BYTEMAN_LIB}/byteman.jar && \
-    sudo cp /tmp/byteman-download-${BYTEMAN_VERSION}/lib/byteman-submit.jar ${BYTEMAN_LIB}/byteman-submit.jar && \
-    sudo cp /tmp/byteman-download-${BYTEMAN_VERSION}/bin/bmsubmit.sh /usr/local/bin/bmsubmit && \
+ENV BYTEMAN_HOME=/opt/byteman
+RUN cd /tmp && \
+    curl -L -o byteman.zip https://downloads.jboss.org/byteman/${BYTEMAN_VERSION}/byteman-download-${BYTEMAN_VERSION}-bin.zip && \
+    unzip -j -d byteman byteman.zip && \
+    sudo mkdir -p ${BYTEMAN_HOME}/lib && \
+    sudo mv byteman/byteman.jar byteman/byteman-submit.jar ${BYTEMAN_HOME}/lib/ && \
+    sudo mv byteman/bmsubmit.sh /usr/local/bin/bmsubmit && \
     sudo chmod +x /usr/local/bin/bmsubmit && \
-    sudo rm -rf /tmp/byteman.zip /tmp/byteman-download-${BYTEMAN_VERSION} && \
-    sudo chmod o+r ${BYTEMAN_LIB}/byteman.jar && \
-    sudo ln -s ${BYTEMAN_LIB}/byteman.jar /opt/byteman.jar
+    sudo rm -rf byteman.zip byteman && \
+    sudo chmod -R a+rX ${BYTEMAN_HOME} && \
+    sudo ln -s ${BYTEMAN_HOME}/lib/byteman.jar /opt/byteman.jar
 
 #async profiler for development profiling
 RUN set -eux ; \


### PR DESCRIPTION
## What changes were proposed in this pull request?

`bmsubmit` uses `BYTEMAN_HOME` to locate its jars.  It should be set in the `ozone-runner` image, so that it does not have to be set by all tests that want to use it.

https://issues.apache.org/jira/browse/HDDS-13336

## How was this patch tested?

```
$ ./build.sh
...

$ docker run -it --rm apache/ozone-runner:dev bash

[root@713ebd0dd025 /]# echo $BYTEMAN_HOME
/opt/byteman

[root@713ebd0dd025 /]# ls -la $BYTEMAN_HOME 
total 12
drwxr-xr-x 3 root root 4096 Jun 25 12:20 .
drwxr-xr-x 1 root root 4096 Jun 25 12:20 ..
drwxr-xr-x 2 root root 4096 Jun 25 12:20 lib

[root@713ebd0dd025 /]# ls -la $BYTEMAN_HOME/lib
total 864
drwxr-xr-x 2 root root   4096 Jun 25 12:20 .
drwxr-xr-x 3 root root   4096 Jun 25 12:20 ..
-rw-r--r-- 1 root root  15535 May  1 17:08 byteman-submit.jar
-rw-r--r-- 1 root root 859806 May  1 17:09 byteman.jar

[root@713ebd0dd025 /]# ls -la $(which bmsubmit)
-rwxr-xr-x 1 root root 3449 Apr  9  2018 /usr/local/bin/bmsubmit

[root@713ebd0dd025 /]# ls -la /opt/byteman.jar 
lrwxrwxrwx 1 root root 28 Jun 25 12:20 /opt/byteman.jar -> /opt/byteman/lib/byteman.jar
```

CI:
https://github.com/adoroszlai/ozone-docker-runner/actions/runs/15876249350/job/44764455447