### PR TITLE
HDDS-13446. Replace goofys with mountpoint-s3 in ozone-docker-runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,14 +47,15 @@ COPY --from=go /go/bin/csc /usr/bin/csc
 # S3 FUSE support
 RUN set -eux ; \
     ARCH="$(arch)"; \
+    MOUNTPOINT_S3_VERSION="1.19.0"; \
     case "${ARCH}" in \
-        x86_64)  arch='x86_64' ;; \
-        aarch64) arch='arm64' ;; \
+        x86_64)  url="https://s3.amazonaws.com/mountpoint-s3-release/${MOUNTPOINT_S3_VERSION}/x86_64/mount-s3-${MOUNTPOINT_S3_VERSION}-x86_64.rpm" ;; \
+        aarch64) url="https://s3.amazonaws.com/mountpoint-s3-release/${MOUNTPOINT_S3_VERSION}/arm64/mount-s3-${MOUNTPOINT_S3_VERSION}-arm64.rpm" ;; \
         *) echo "Unsupported architecture: ${ARCH}"; exit 1 ;; \
     esac; \
-    curl -L -o /tmp/mount-s3.rpm "https://s3.amazonaws.com/mountpoint-s3-release/latest/${arch}/mount-s3.rpm"; \
-    dnf install -y /tmp/mount-s3.rpm; \
-    rm -f /tmp/mount-s3.rpm
+    curl -L ${url} -o mount-s3.rpm ; \
+    dnf install -y mount-s3.rpm ; \
+    rm -f mount-s3.rpm
 
 # Install rclone for smoketest
 ARG RCLONE_VERSION=1.69.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,11 +49,11 @@ ARG MOUNTPOINT_S3_VERSION=1.19.0
 RUN set -eux ; \
     ARCH="$(arch)"; \
     case "${ARCH}" in \
-        x86_64)  url="https://s3.amazonaws.com/mountpoint-s3-release/${MOUNTPOINT_S3_VERSION}/x86_64/mount-s3-${MOUNTPOINT_S3_VERSION}-x86_64.rpm" ;; \
-        aarch64) url="https://s3.amazonaws.com/mountpoint-s3-release/${MOUNTPOINT_S3_VERSION}/arm64/mount-s3-${MOUNTPOINT_S3_VERSION}-arm64.rpm" ;; \
+        x86_64)  arch='x86_64' ;; \
+        aarch64) arch='arm64' ;; \
         *) echo "Unsupported architecture: ${ARCH}"; exit 1 ;; \
     esac; \
-    curl -L ${url} -o mount-s3.rpm ; \
+    curl -L "https://s3.amazonaws.com/mountpoint-s3-release/${MOUNTPOINT_S3_VERSION}/${arch}/mount-s3-${MOUNTPOINT_S3_VERSION}-${arch}.rpm" -o mount-s3.rpm ; \
     dnf install -y mount-s3.rpm ; \
     rm -f mount-s3.rpm
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,10 +44,10 @@ RUN sudo python3 -m pip install --upgrade pip
 
 # CSI / k8s / fuse / goofys dependency
 COPY --from=go /go/bin/csc /usr/bin/csc
-# S3 FUSE support
+# S3 FUSE support - mountpoint-s3
+ARG MOUNTPOINT_S3_VERSION=1.19.0
 RUN set -eux ; \
     ARCH="$(arch)"; \
-    MOUNTPOINT_S3_VERSION="1.19.0"; \
     case "${ARCH}" in \
         x86_64)  url="https://s3.amazonaws.com/mountpoint-s3-release/${MOUNTPOINT_S3_VERSION}/x86_64/mount-s3-${MOUNTPOINT_S3_VERSION}-x86_64.rpm" ;; \
         aarch64) url="https://s3.amazonaws.com/mountpoint-s3-release/${MOUNTPOINT_S3_VERSION}/arm64/mount-s3-${MOUNTPOINT_S3_VERSION}-arm64.rpm" ;; \


### PR DESCRIPTION
## What changes were proposed in this pull request?

Apache Ozone presently utilizes `goofys` as its S3 FUSE implementation. Given that the `goofys` repository has been forked and is now under the maintenance of StatCan, our intention is to transition to `mountpoint-s3`, an AWS Labs-maintained package, for subsequent development efforts.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13446

## How was this patch tested?

```
$ ./build.sh
...

$ docker run -it --rm apache/ozone-runner:dev bash

[hadoop@e9911f14f942 ~]$ which mount-s3
/usr/bin/mount-s3

[hadoop@e9911f14f942 ~]$ which goofys
/usr/bin/which: no goofys in 
```

CI: https://github.com/echonesis/ozone-docker-runner/actions/runs/16337455101