### PR TITLE
HDDS-15340. [INFRA] Set up ruleset for default and release branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -26,12 +26,25 @@ github:
   autolink_jira:
     - HDDS
   enabled_merge_buttons:
-    squash:  true
+    squash: true
     squash_commit_message: PR_TITLE
-    merge:   false
-    rebase:  false
+    merge: false
+    rebase: false
+  rulesets:
+    - name: "Default Branch Protection"
+      type: branch
+      branches:
+        includes:
+          - "~DEFAULT_BRANCH"
+          - "release/*"
+          - "rel/*"
+        excludes: []
+      bypass_teams:
+        - root
+      restrict_deletion: true
+      restrict_force_push: true
 notifications:
-  commits:      commits@ozone.apache.org
-  issues:       issues@ozone.apache.org
+  commits: commits@ozone.apache.org
+  issues: issues@ozone.apache.org
   pullrequests: issues@ozone.apache.org
   jira_options: link label worklog

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -36,8 +36,8 @@ github:
       branches:
         includes:
           - "~DEFAULT_BRANCH"
-          - "release/*"
-          - "rel/*"
+          - "jdk*"
+          - "slim"
         excludes: []
       bypass_teams:
         - root


### PR DESCRIPTION
This Pull Request enables the repository to conform with the "sane default security settings" of the Apache Software Foundation by configuring a default branch ruleset that protects the default branch and any release branches.

Note that `~DEFAULT_BRANCH` is a GitHub symbolic link to the current default branch (HEAD) of the repository and does not need changing.
If the managing project does not wish to set up these defaults, please close this Pull Request. Alternatively, the project may merge this Pull Request to apply the changes immediately.

If no action is taken, this Pull Request will be automatically merged by the Apache Infrastructure team on **2026-06-14** (30 days from now).

For any further information, please reach us on Slack or at: users@infra.apache.org
