### PR TITLE
Revert "HDDS-12804. Include Hadoop native library libhadoop.so (#46)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,20 +124,6 @@ RUN set -eux ; \
     curl -L ${url} | tar xvz ; \
     mv async-profiler-* /opt/profiler
 
-# Hadoop native libary
-RUN set -eux ; \
-    ARCH="$(arch)" ; \
-    hadoop_version=3.4.2 ; \
-    case "${ARCH}" in \
-        x86_64)  file=hadoop-${hadoop_version}-lean.tar.gz ;; \
-        aarch64) file=hadoop-${hadoop_version}-aarch64-lean.tar.gz ;; \
-        *) echo "Unsupported architecture: ${ARCH}"; exit 1 ;; \
-    esac; \
-    curl -L "https://www.apache.org/dyn/closer.lua?action=download&filename=hadoop/common/hadoop-${hadoop_version}/$file" -o "hadoop-${hadoop_version}.tar.gz" && \
-    tar xzvf hadoop-${hadoop_version}.tar.gz -C /usr/lib --strip-components 3 "hadoop-${hadoop_version}/lib/native/libhadoop.*" && \
-    chown --no-dereference root:root /usr/lib/libhadoop* && \
-    rm -f hadoop-${hadoop_version}.tar.gz
-
 # OpenJDK 21
 RUN set -eux ; \
     ARCH="$(arch)"; \


### PR DESCRIPTION
After HDDS-15559 is merged, there is no need to download and embed hadoop native library into default ozone docker image. 