### PR TITLE
HDDS-15662. Remove exclusion of tar upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,9 @@
 FROM golang:1.17.8-buster AS go
 RUN go install github.com/rexray/gocsi/csc@latest
 
-# Security update RHSA-2026:0067 breaks tar on arm64.
-# Remove exclusion if package newer than tar-1.34-9.el9_7 is available (and works OK)
 FROM rockylinux/rockylinux:9
 RUN set -eux ; \
     dnf upgrade -y \
-      --exclude tar \
     && dnf install -y \
       bzip2 \
       diffutils \


### PR DESCRIPTION
## What changes were proposed in this pull request?

`tar` was held back from upgrade in https://github.com/apache/ozone-docker-runner/pull/53#issuecomment-3819591799 due to failure in extraction during image build.  New version `tar-1.34-11.el9` works fine, no longer needs to be held back from upgrade.

https://issues.apache.org/jira/browse/HDDS-15662

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone-docker-runner/actions/runs/28128228711