### PR TITLE
HDDS-15669. Create ozone-runner with JDK25

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ To run complete Ozone CI with the custom image:
 1. Fetch changes to your local clone.
 2. Add a Git tag for the commit following the existing pattern `<date>-<n>-<flavor>`, where
     - `<n>` starts at 1, and is incremented if multiple images need to be published the same day)
-    - `<flavor>` is one of: `jdk21`, `jdk11`, `jdk8`, `slim`
+    - `<flavor>` is one of: `jdk25`, `jdk21`, `jdk11`, `jdk8`, `slim`
 3. Push the Git tag to the official repo (`apache/ozone-docker-runner`).  This will trigger a workflow to apply the tag to the Docker image.
 4. Set `Fix Version` of the Jira issue to `runner-<date>-<n>-<flavor>`
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -124,17 +124,17 @@ RUN set -eux ; \
     curl -L ${url} | tar xvz ; \
     mv async-profiler-* /opt/profiler
 
-# OpenJDK 21
+# OpenJDK 25
 RUN set -eux ; \
     ARCH="$(arch)"; \
     case "${ARCH}" in \
         x86_64) \
-            url='https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_linux-x64_bin.tar.gz'; \
-            sha256='a2def047a73941e01a73739f92755f86b895811afb1f91243db214cff5bdac3f'; \
+            url='https://download.java.net/java/GA/jdk25.0.2/b1e0dfa218384cb9959bdcb897162d4e/10/GPL/openjdk-25.0.2_linux-x64_bin.tar.gz'; \
+            sha256='555ce0821e4fe175ea50d54518cd6fbece9663c1998de529bc6ce429534457df'; \
             ;; \
         aarch64) \
-            url='https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_linux-aarch64_bin.tar.gz'; \
-            sha256='08db1392a48d4eb5ea5315cf8f18b89dbaf36cda663ba882cf03c704c9257ec2'; \
+            url='https://download.java.net/java/GA/jdk25.0.2/b1e0dfa218384cb9959bdcb897162d4e/10/GPL/openjdk-25.0.2_linux-aarch64_bin.tar.gz'; \
+            sha256='671208d205e70c9805da45a483f670d49dd64654990a7b7223ccffb2abb070dd'; \
             ;; \
         *) echo "Unsupported architecture: ${ARCH}"; exit 1 ;; \
     esac && \
@@ -143,7 +143,7 @@ RUN set -eux ; \
     tar xzvf openjdk.tar.gz -C /usr/local && \
     rm -f openjdk.tar.gz
 
-ENV JAVA_HOME=/usr/local/jdk-21.0.2
+ENV JAVA_HOME=/usr/local/jdk-25.0.2
 # compatibility with Ozone 1.4.0 and earlier compose env.
 RUN mkdir -p /usr/lib/jvm && ln -s $JAVA_HOME /usr/lib/jvm/jre
 

--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@
 
 Published to [Docker Hub](https://hub.docker.com/r/apache/ozone-runner) and [GitHub](https://github.com/apache/ozone-docker-runner/pkgs/container/ozone-runner).
 
-Images are tagged by date, and come in two flavors: `jdk21` (for Ozone 2.0+) and `jdk11` (for Ozone 1.x).
+Images are tagged by date, and come in flavors based on JDK version.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Install JDK 25 in `ozone-runner` so that we can test Ozone with it.  Update docs to mention `jdk25`.

If merged, will create branch for `jdk21` variant starting at the previous commit on `master`.

https://issues.apache.org/jira/browse/HDDS-15669

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone-docker-runner/actions/runs/28167782102

```
$ docker run -it --rm ghcr.io/adoroszlai/ozone-runner:034d125b27740d3d300ff14811631623d1f514ac java -version
To use Ozone please mount ozone folder to /opt/hadoop
openjdk version "25.0.2" 2026-01-20
OpenJDK Runtime Environment (build 25.0.2+10-69)
OpenJDK 64-Bit Server VM (build 25.0.2+10-69, mixed mode, sharing)
```