### PR TITLE
HDDS-14415. Bump Go builder for csc to 1.26 and pin gocsi to v1.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17.8-buster AS go
-RUN go install github.com/rexray/gocsi/csc@latest
+FROM golang:1.26-bookworm AS go
+RUN go install github.com/rexray/gocsi/csc@v1.2.2
 
 FROM rockylinux/rockylinux:9
 RUN set -eux ; \


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update the Go builder stage for `csc` from `golang:1.17.8-buster` to `golang:1.26-bookworm`:
- Go 1.17 is no longer supported ([release policy](https://go.dev/doc/devel/release)); 1.26 is the current stable release.
- Debian 10 (buster) reached [end-of-life on June 30, 2024](https://www.debian.org/News/2024/20240615).

Also pin `gocsi` to [v1.2.2](https://github.com/rexray/gocsi/releases) (the version `@latest` currently resolves to) instead of `@latest`, to avoid unexpected version changes, similar to #45.

Note: the goofys part of the Jira was already handled by HDDS-13446 (goofys was replaced with mountpoint-s3).

https://issues.apache.org/jira/browse/HDDS-14415

## How was this patch tested?

CI:
https://github.com/chihsuan/ozone-docker-runner/actions/runs/30063730470

```console
$ docker run -it --rm ghcr.io/chihsuan/ozone-runner:bdb358de7231f85c92c98ad169af17266dd54f07 csc
To use Ozone please mount ozone folder to /opt/hadoop
NAME
    csc -- a command line container storage interface (CSI) client

SYNOPSIS
    csc [flags] CMD

AVAILABLE COMMANDS
    controller
    identity
    node
```