### PR TITLE
HDDS-15977. Remove mountpoint-s3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.26-bookworm AS go
-RUN go install github.com/rexray/gocsi/csc@v1.2.2
-
 FROM rockylinux/rockylinux:9
 RUN set -eux ; \
     dnf upgrade -y \
@@ -41,9 +38,6 @@ RUN set -eux ; \
     && dnf clean all \
     && ln -sf /usr/bin/python3 /usr/bin/python
 RUN python3 -m pip install --upgrade pip
-
-# CSI / k8s dependency
-COPY --from=go /go/bin/csc /usr/bin/csc
 
 # Install rclone for smoketest
 ARG RCLONE_VERSION=1.69.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ RUN set -eux ; \
       bzip2 \
       diffutils \
       findutils \
-      fuse \
       jq \
       krb5-workstation \
       libxcrypt-compat \
@@ -43,20 +42,8 @@ RUN set -eux ; \
     && ln -sf /usr/bin/python3 /usr/bin/python
 RUN python3 -m pip install --upgrade pip
 
-# CSI / k8s / fuse / goofys dependency
+# CSI / k8s dependency
 COPY --from=go /go/bin/csc /usr/bin/csc
-# S3 FUSE support - mountpoint-s3
-ARG MOUNTPOINT_S3_VERSION=1.19.0
-RUN set -eux ; \
-    ARCH="$(arch)"; \
-    case "${ARCH}" in \
-        x86_64)  arch='x86_64' ;; \
-        aarch64) arch='arm64' ;; \
-        *) echo "Unsupported architecture: ${ARCH}"; exit 1 ;; \
-    esac; \
-    curl -L "https://s3.amazonaws.com/mountpoint-s3-release/${MOUNTPOINT_S3_VERSION}/${arch}/mount-s3-${MOUNTPOINT_S3_VERSION}-${arch}.rpm" -o mount-s3.rpm ; \
-    dnf install -y mount-s3.rpm ; \
-    rm -f mount-s3.rpm
 
 # Install rclone for smoketest
 ARG RCLONE_VERSION=1.69.3


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove `mountpoint-s3` and `csc` from the runner image. HDDS-15876 removed ozone-csi, so neither the S3 FUSE mount support nor the CSI command line client is used by anything in the project.

- Drop the `MOUNTPOINT_S3_VERSION` build arg and the `RUN` layer that downloads and installs the `mount-s3` RPM.
- Drop the `fuse` package from the `dnf install` list — `mountpoint-s3` was its only consumer.
- Drop the `golang` builder stage that installs `gocsi/csc`, and the `COPY` that puts `csc` into the image.

## What is the link to the Apache JIRA?

https://issues.apache.org/jira/browse/HDDS-15977

## How was this patch tested?

Relies on the CI image build on this PR.
