### PR TITLE
HDDS-16305. Add version tag for pinned infra actions

### DIFF
--- a/.github/workflows/asf-allowlist-check.yaml
+++ b/.github/workflows/asf-allowlist-check.yaml
@@ -44,6 +44,6 @@ jobs:
         with:
           persist-credentials: false
       - name: Check actions
-        uses: apache/infrastructure-actions/allowlist-check@69afc125e535c4c41e7f1b7470f583087e0f344b
+        uses: apache/infrastructure-actions/allowlist-check@61dcea11f19e2bbe1263f14d72235e8da17d3ad0 # allowlist-check/v1.0.0
         with:
           scan-glob: ".github/workflows/*.y*ml"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Dependabot started updating `apache/infrastructure-actions/allowlist-check` (e.g. #105) when there were no changes in the action, only other parts of the infra repo.  The action is pinned by SHA without tag comment.  This PR adds tag comment (and changes SHA to match the tag) to prevent these unnecessary dependabot updates.

https://issues.apache.org/jira/browse/HDDS-16305

## How was this patch tested?

Same fix verified in `ratis-thirdparty` repo, dependabot closed the unnecessary pull requests (e.g. https://github.com/apache/ratis-thirdparty/pull/183#issuecomment-5435380599).

https://github.com/adoroszlai/ozone-docker-runner/actions/runs/33047353322
